### PR TITLE
feat: task list MVP

### DIFF
--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Task } from '@/lib/db';
+import { useTaskStore } from '@/lib/store/task';
 
 /**
  * A component to render a single task.
@@ -13,21 +14,19 @@ import { Task } from '@/lib/db';
 export const TaskItem = ({ task }: { task: Task }) => {
   const [menuOpen, setMenuOpen] = useState(false); // TODO: move menu to its own component
 
+  const { deleteTask, toggleComplete } = useTaskStore();
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
   };
 
   return (
     <li className="flex items-center justify-between p-4 mb-2 bg-white border border-gray-200 rounded-md shadow-sm hover:shadow-md transition-shadow">
-      <div
-        className="flex items-center space-x-4"
-        //style={{ border: '2px solid red' }}
-      >
+      <div className="flex items-center space-x-4">
         <input
           type="checkbox"
           checked={task.completed}
           className="form-checkbox h-5 w-5 text-blue-500 rounded focus:ring focus:ring-blue-200"
-          onChange={() => console.log('Handle completion toggle here')} //TODO: Handle completion toggle
+          onChange={() => toggleComplete(task.id)}
         />
         <span
           className={`text-gray-800 ${
@@ -74,17 +73,18 @@ export const TaskItem = ({ task }: { task: Task }) => {
         {/* Dropdown Menu */}
         {menuOpen && (
           <ul className="absolute right-0 mt-2 w-32 bg-white border border-gray-200 rounded-lg shadow-lg text-sm z-10">
-            <li>
+            {/* TODO: Add edit functionality */}
+            {/* <li>
               <button
                 //onClick={handleEdit}
                 className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100"
               >
                 Edit
               </button>
-            </li>
+            </li> */}
             <li>
               <button
-                //onClick={handleDelete}
+                onClick={() => deleteTask(task.id)}
                 className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100"
               >
                 Delete

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -36,4 +36,17 @@ export class TaskService {
     // delete the task from the database
     await db.tasks.delete(id);
   };
+
+  toggleComplete = async (id: string) => {
+    const task = await db.tasks.get(id);
+
+    if (task) {
+      const updatedTask = {
+        ...task,
+        completed: !task.completed,
+        dateUpdated: new Date(),
+      };
+      await db.tasks.update(id, updatedTask);
+    }
+  };
 }

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -6,9 +6,10 @@ interface TaskStore {
   tasks: Task[];
   fetchTasks: () => Promise<void>;
   addTask: (task: Task) => void;
+  deleteTask: (id: string) => void;
+  toggleComplete: (id: string) => void;
   //TODO:
   // updateTask: (updatedTask: Task) => void;
-  // removeTask: (taskId: string) => void;
 }
 
 export const useTaskStore = create<TaskStore>((set) => ({
@@ -32,6 +33,38 @@ export const useTaskStore = create<TaskStore>((set) => ({
     // update the store with the new task
     set((state) => ({
       tasks: [...state.tasks, newTask],
+    }));
+  },
+
+  /**
+   * Remove a task from the store. This function will delete the task from the
+   * Dexie database and then update the store without the task.
+   *
+   * @param {string} id The id of the task to remove from the store.
+   * @returns {void}
+   */
+  deleteTask: async (id: string) => {
+    // remove the task from the dexie database
+    await taskService.deleteTask(id);
+    // update the store with the new task
+    set((state) => ({
+      tasks: state.tasks.filter((task) => task.id !== id),
+    }));
+  },
+
+  // toggle task completion
+  toggleComplete: async (id: string) => {
+    // update the task in the dexie database
+    await taskService.toggleComplete(id);
+    // update the store with the new task
+    // what would be a more direct way to update this? get the task back from the dexie database and use that?
+    set((state) => ({
+      tasks: state.tasks.map((task) => {
+        if (task.id === id) {
+          return { ...task, completed: !task.completed };
+        }
+        return task;
+      }),
     }));
   },
 }));


### PR DESCRIPTION
With this PR we complete the MVP functionality for tasks - my goal is to keep this very simple and build up the different parts together. 

Right now the user can:
- Add a new task
- Toggle it's completed status (appears crossed out)
- Delete a task 

This does not include any mass actions or update functionality. This is a task list, it's not crazy to expect the user (at *MVP stage*) to simply remove a task and re-add it if they want to edit it (as the only thing we'd edit is the text). In the future, when tasks can have categories, a scoring number, etc, we will provide a way to update items. 

Next the goal will be to introduce a live text editor and create a 'digital bulletin board'. I see the notes being handy, small reminders, and allowing them to be linked to tasks could provide for some interesting and helpful visual (color coded?) presentations. 

