### PR TITLE
feat: adds note board display

### DIFF
--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -16,6 +16,7 @@ import { TaskItem } from './TaskItem';
 const ClientTaskList = (): React.ReactElement => {
   const { tasks, fetchTasks } = useTaskStore();
 
+  // TODO: fetch tasks differently - not in a useEffect
   useEffect(() => {
     fetchTasks();
   }, [fetchTasks]);

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useNoteStore } from '@/lib/store/note';
+import NoteDisplay from './NoteDisplay';
+
+const NoteBoardDisplay = (): React.ReactElement => {
+  const { notes, fetchNotes } = useNoteStore();
+
+  // TODO: fetch notes differently - not in a useEffect
+  useEffect(() => {
+    fetchNotes();
+  }, [fetchNotes]);
+
+  return (
+    <ul>
+      {notes.map((note) => (
+        <NoteDisplay key={note.id} content={note.content} />
+      ))}
+    </ul>
+  );
+};
+
+export default NoteBoardDisplay;

--- a/app/components/NoteBoard/NoteDisplay.tsx
+++ b/app/components/NoteBoard/NoteDisplay.tsx
@@ -1,0 +1,18 @@
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
+const NoteDisplay = ({ content }: { content: Record<string, object> }) => {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content,
+    editable: false, // it might be cool to have in-place editing in the future
+  });
+
+  return (
+    <div className="border rounded-md bg-gray-100 p-4">
+      <EditorContent editor={editor} />
+    </div>
+  );
+};
+
+export default NoteDisplay;

--- a/app/components/NoteBoard/index.ts
+++ b/app/components/NoteBoard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NoteBoard';

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import AddTasks from '../components/AddTasks';
 import ClientTaskList from '../components/ClientTaskList';
+import NoteDisplay from '../components/NoteBoard';
 import TextEditor from '../components/TextEditor';
 
 export default async function VideoPage() {
@@ -18,6 +19,7 @@ export default async function VideoPage() {
         <AddTasks />
       </div>
       <div className="p-6 pl-2">
+        <NoteDisplay />
         <TextEditor />
       </div>
     </div>


### PR DESCRIPTION
The next MVP item up was to build a way to render and view written notes. 

`tiptap` offers us a readonly configuration setting, so we didn't need to fuss with converting JSON to HTML or any other format: 

<img width="645" alt="image" src="https://github.com/user-attachments/assets/be8cf3ed-76c7-4a72-a851-4f9cebf284b8">
