### PR TITLE
feat: reusable MeatballMenu, update note board

### DIFF
--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
+import MeatballMenu from '../MeatballMenu';
 
 /**
  * A component to render a single task.
@@ -12,12 +13,19 @@ import { useTaskStore } from '@/lib/store/task';
  * @returns {React.ReactElement} A JSX element representing the task list item.
  */
 export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
-  const [menuOpen, setMenuOpen] = useState(false); // TODO: move menu to its own component
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const { deleteTask, toggleComplete } = useTaskStore();
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
   };
+
+  const menuItems = [
+    {
+      label: 'Delete',
+      onClick: () => deleteTask(task.id),
+    },
+  ];
 
   return (
     <li className="flex items-center justify-between p-4 mb-2 bg-white border border-gray-200 rounded-md shadow-sm hover:shadow-md transition-shadow">
@@ -55,44 +63,11 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
         </span>
       )} */}
 
-      <div className="relative">
-        <button
-          onClick={toggleMenu}
-          className="p-2 rounded-full hover:bg-gray-200"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-5 w-5 text-gray-600"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-          </svg>
-        </button>
-
-        {/* Dropdown Menu */}
-        {menuOpen && (
-          <ul className="absolute right-0 mt-2 w-32 bg-white border border-gray-200 rounded-lg shadow-lg text-sm z-10">
-            {/* TODO: Add edit functionality */}
-            {/* <li>
-              <button
-                //onClick={handleEdit}
-                className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100"
-              >
-                Edit
-              </button>
-            </li> */}
-            <li>
-              <button
-                onClick={() => deleteTask(task.id)}
-                className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100"
-              >
-                Delete
-              </button>
-            </li>
-          </ul>
-        )}
-      </div>
+      <MeatballMenu
+        menuOpen={menuOpen}
+        toggleMenu={toggleMenu}
+        items={menuItems}
+      />
     </li>
   );
 };

--- a/app/components/MeatballMenu.tsx
+++ b/app/components/MeatballMenu.tsx
@@ -1,0 +1,70 @@
+interface MenuItem {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  // icon?: React.ReactNode; //TODO: Might want an icon for each menu item?
+}
+
+interface MeatballMenuProps {
+  menuOpen: boolean;
+  toggleMenu: () => void;
+  items: MenuItem[];
+  className?: string;
+}
+
+/**
+ * A dropdown menu component that renders a button with a stacked meatball icon and a list
+ * of menu items. The menu is toggled on click.
+ *
+ * @param {{ menuOpen: boolean; toggleMenu: () => void; items: { label: string; onClick: () => void; disabled?: boolean }[]; className?: string; }}
+ * @returns
+ */
+const MeatballMenu = ({
+  menuOpen,
+  toggleMenu,
+  items,
+  className = '',
+}: MeatballMenuProps) => {
+  return (
+    <div className={`relative ${className}`}>
+      <button
+        onClick={toggleMenu}
+        className="p-2 rounded-full hover:bg-gray-200"
+        aria-haspopup="true"
+        aria-expanded={menuOpen}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5 text-gray-600"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+        </svg>
+      </button>
+
+      {menuOpen && (
+        <ul className="absolute right-0 mt-2 w-32 bg-white border border-gray-200 rounded-lg shadow-lg text-sm z-10">
+          {items.map(({ label, onClick, disabled }, index) => (
+            <li key={index} role="menuitem">
+              <button
+                onClick={onClick}
+                disabled={disabled}
+                className={`flex items-center w-full px-4 py-2 text-left ${
+                  disabled
+                    ? 'text-gray-400 cursor-not-allowed'
+                    : 'text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                {/* {icon && <span className="mr-2">{icon}</span>} */}
+                {label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default MeatballMenu;

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -15,7 +15,7 @@ const NoteBoardDisplay = (): React.ReactElement => {
   return (
     <ul>
       {notes.map((note) => (
-        <NoteDisplay key={note.id} content={note.content} />
+        <NoteDisplay key={note.id} id={note.id} content={note.content} />
       ))}
     </ul>
   );

--- a/app/components/NoteBoard/NoteDisplay.tsx
+++ b/app/components/NoteBoard/NoteDisplay.tsx
@@ -6,8 +6,6 @@ import StarterKit from '@tiptap/starter-kit';
 import { useNoteStore } from '@/lib/store/note';
 import MeatballMenu from '../MeatballMenu';
 
-//TODO: We want a meatball menu like the tasks have
-// we'll need to pass the note id to the meatball menu - we need to accept more metadata here
 const NoteDisplay = ({
   content,
   id,

--- a/app/components/NoteBoard/NoteDisplay.tsx
+++ b/app/components/NoteBoard/NoteDisplay.tsx
@@ -1,16 +1,51 @@
+'use client';
+
+import { useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import { useNoteStore } from '@/lib/store/note';
+import MeatballMenu from '../MeatballMenu';
 
-const NoteDisplay = ({ content }: { content: Record<string, object> }) => {
+//TODO: We want a meatball menu like the tasks have
+// we'll need to pass the note id to the meatball menu - we need to accept more metadata here
+const NoteDisplay = ({
+  content,
+  id,
+}: {
+  content: Record<string, object>;
+  id: string;
+}) => {
   const editor = useEditor({
     extensions: [StarterKit],
     content,
     editable: false, // it might be cool to have in-place editing in the future
   });
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const { deleteNote } = useNoteStore();
+
+  const menuItems = [
+    {
+      label: 'Delete',
+      onClick: () => {
+        deleteNote(id);
+      },
+    },
+  ];
 
   return (
-    <div className="border rounded-md bg-gray-100 p-4">
+    <div
+      className="flex border rounded-md bg-green-100 p-4"
+      style={{
+        justifyContent: 'space-between',
+      }}
+    >
       <EditorContent editor={editor} />
+      <MeatballMenu
+        menuOpen={menuOpen}
+        toggleMenu={() => setMenuOpen(!menuOpen)}
+        items={menuItems}
+      />
     </div>
   );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,8 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: 'JS Fullstack Challenge',
-  description: '',
+  title: 'Habit Nest',
+  description: 'Stay on track with your habits',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
- Creates a reusable `MeatballMenu`, updates Tasks and Notes to use the new menu
- Hooks up delete functionality on Notes 

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/49ffb07a-e5b3-494f-aadb-2d0b7936f387">