### PR TITLE
feat: add basic header

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useStore, Theme } from '@/lib/store/app';
+
+/**
+ * A header component that renders a navigation bar with a theme selector and a view selector.
+ *
+ * It uses the `useStore` hook to access the state of the application, AppState
+ *
+ * The theme selector allows users to switch between a light and dark theme
+ * The view selector allows users to switch between viewing tasks and notes, or both
+ *
+ * View selector is disabled for now, as the logic is not implemented yet
+ *
+ * @returns {JSX.Element} The JSX element representing the header.
+ */
+function Header(): JSX.Element {
+  const { theme, setTheme } = useStore(); // Zustand selectors.
+
+  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    //TODO: type research needed:
+    const theme = e.target.value as Theme; // type casting - not sure if this is the best way
+    setTheme(theme);
+  };
+
+  return (
+    <header className="bg-gray-50 dark:bg-gray-800 p-4 px-8 shadow-md flex justify-between items-center">
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+        HabitNest
+      </h1>
+      <div className="flex items-center space-x-4">
+        {/* Theme Selector */}
+        <select
+          value={theme}
+          onChange={handleThemeChange}
+          className="bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 p-2 rounded"
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          {/* <option value="custom">Custom</option> */}
+        </select>
+
+        {/* View Selector */}
+        {/* <select
+          value={view}
+          onChange={(e) => setView(e.target.value)}
+          className="bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 p-2 rounded"
+        >
+          <option value="both">Tasks & Notes</option>
+          <option value="tasks">Tasks Only</option>
+          <option value="notes">Notes Only</option>
+        </select> */}
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
+import Header from './components/layout/Header';
 import './globals.css';
 
 const geistSans = localFont({
@@ -28,6 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/lib/store/app.ts
+++ b/lib/store/app.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+export enum Theme {
+  Light = 'light',
+  Dark = 'dark',
+}
+
+interface AppState {
+  view: {
+    tasks: boolean;
+    notes: boolean;
+  };
+  setView: (view: keyof AppState['view'], value: boolean) => void;
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useStore = create<AppState>((set) => ({
+  view: {
+    tasks: true,
+    notes: true,
+  },
+  setView: (view, value) => {
+    set((state) => ({
+      view: {
+        ...state.view, // preserve existing view
+        [view]: value, // update the specific view
+      },
+    }));
+  },
+  theme: Theme.Light,
+  setTheme: (theme) => set({ theme }),
+}));


### PR DESCRIPTION
- Adds a header for the project
- The header features a theme selector 
- Adds a new Zustand store for `AppState` - i.e. what views the user has 'turned on', and a way to change the theme 

Themes don't currently exist, as approaching that will be our next effort before the app gets any larger. 

I need to do some research on design tokens (or something like it) in use with Tailwind, so that all the colors can be tied to theme values like `Theme.Primary` - and that can dynamically point to different values depending on the `Theme` selection. 