### PR TITLE
feat: adds optional color assignment, links tasks and notes

### DIFF
--- a/app/components/AddTasks.tsx
+++ b/app/components/AddTasks.tsx
@@ -31,6 +31,13 @@ const AddTasks = () => {
         className="flex-grow bg-transparent outline-none placeholder-gray-500"
         placeholder="Add a task..."
       />
+      {/** TODO: build a Select to choose the task color - string selections like 'red' 'blue' etc */}
+      {/* <select>
+        <option value="red">Red</option>
+        <option value="blue">Blue</option>
+        <option value="green">Green</option>
+      </select> */}
+
       <button onClick={handleAddTask}>Add</button>
     </div>
   );

--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -20,6 +20,7 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
     setMenuOpen(!menuOpen);
   };
 
+  //TODO: add 'Change color' menu item - figure out how this will work
   const menuItems = [
     {
       label: 'Delete',

--- a/app/components/TextEditor/TextEditor.tsx
+++ b/app/components/TextEditor/TextEditor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useNoteStore } from '@/lib/store/note';
@@ -13,10 +14,17 @@ import Toolbar from './Toolbar';
 const TextEditor = (): React.ReactElement => {
   const { addNote } = useNoteStore();
 
+  // following these docs: https://tiptap.dev/docs/editor/extensions/functionality/placeholder
+  // but this doesn't appear to be working as expected - wonder why?
+  // TODO: check versions, check any next js configs that might be causing issues
   const editor = useEditor({
-    extensions: [StarterKit],
-    content: `
-      <p> Write your notes here! </p>`,
+    extensions: [
+      StarterKit,
+      Placeholder.configure({
+        placeholder: 'Write your notes here!',
+      }),
+    ],
+    content: '',
   });
 
   const saveNote = () => {
@@ -24,6 +32,10 @@ const TextEditor = (): React.ReactElement => {
     if (!content) return;
 
     addNote(content);
+
+    // clear the contents and refocus the editor
+    editor?.commands.clearContent();
+    editor?.commands.focus();
   };
 
   return (
@@ -31,11 +43,12 @@ const TextEditor = (): React.ReactElement => {
       <Toolbar editor={editor} />
       <EditorContent
         editor={editor}
+        //className="min-h-[200px] focus:outline-none active:outline-none"
         className="h-64 overflow-y-auto bg-white border rounded-b p-2"
       />
       <button
         className="w-full text-center font-bold py-2 px-4 mt-4 rounded-md
-        bg-primary hover:bg-blue-600 text-white"
+        bg-primary hover:bg-secondary text-white"
         onClick={saveNote}
       >
         Save Note

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,6 +4,7 @@ export interface Task {
   id: string;
   text: string;
   completed: boolean;
+  color?: string; // the user assigned color for the task background - a string
   dateAdded: Date;
   dateUpdated: Date;
 }
@@ -11,6 +12,7 @@ export interface Task {
 export interface Note {
   id: string;
   content: Record<string, object>; // better reflect the JSON received from TipTap
+  color?: string; // the user assigned color for the note background - a string
   dateAdded: Date;
   dateUpdated: Date;
 }
@@ -18,6 +20,7 @@ export interface Note {
 class AppDatabase extends Dexie {
   tasks: Dexie.Table<Task, string>;
   notes: Dexie.Table<Note, string>;
+  taskNotes: Dexie.Table<{ taskId: string; noteId: string }, [string, string]>;
 
   constructor() {
     super('ProductivityAppDB');
@@ -39,8 +42,22 @@ class AppDatabase extends Dexie {
       notes: '&id, content, dateAdded, dateUpdated',
     });
 
+    // update:
+    // colors on tasks and notes
+    // links tasks and notes with a taskNotes table
+    this.version(4).stores({
+      tasks: '&id, text, completed, color, dateAdded, dateUpdated',
+      notes: '&id, content, color, dateAdded, dateUpdated',
+
+      // composite key for primary key, a tuple with 2 elements
+      // prevents duplicate relationships for the same task and note
+      // how would this scale?
+      taskNotes: '[taskId+noteId], taskId, noteId',
+    });
+
     this.tasks = this.table('tasks');
     this.notes = this.table('notes');
+    this.taskNotes = this.table('taskNotes');
   }
 }
 

--- a/lib/services/note.ts
+++ b/lib/services/note.ts
@@ -9,10 +9,11 @@ export class NoteService {
     return await db.notes.toArray();
   }
 
-  addNote = async (content: Record<string, object>) => {
+  addNote = async (content: Record<string, object>, color?: string) => {
     const note = {
       id: crypto.randomUUID(),
       content,
+      color,
       dateAdded: new Date(),
       dateUpdated: new Date(),
     };
@@ -26,6 +27,20 @@ export class NoteService {
     const updatedNote = { ...note, dateUpdated: new Date() };
     await db.tasks.update(note.id, updatedNote);
     return updatedNote;
+  };
+
+  updateNoteColor = async (id: string, color: string) => {
+    const note = await db.notes.get(id);
+
+    if (note) {
+      const updatedNote = { ...note, color, dateUpdated: new Date() };
+      await db.notes.update(id, updatedNote);
+      return updatedNote;
+    }
+
+    console.warn(
+      `Note with id ${id} could not be found - color not updated 😢`
+    );
   };
 
   deleteNote = async (id: string) => {

--- a/lib/services/note.ts
+++ b/lib/services/note.ts
@@ -29,6 +29,11 @@ export class NoteService {
     return updatedNote;
   };
 
+  /**
+   * Update the color of a note background in the UI
+   * @param {string} id - The id of the task to update
+   * @param {string} color - The color to update the task with
+   */
   updateNoteColor = async (id: string, color: string) => {
     const note = await db.notes.get(id);
 

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -49,10 +49,11 @@ export class TaskService {
     }
   };
 
-  // update only the color of the task
-  // ease of use function for future on the frontend Task UI
-  // we still need to add base update functionality for the tasks
-  // but I see myself wanting to easily change the color of tasks without impacting anything else
+  /**
+   * Update the color of a task background in the UI
+   * @param {string} id - The id of the task to update
+   * @param {string} color - The color to update the task with
+   */
   updateTaskColor = async (id: string, color: string) => {
     const task = await db.tasks.get(id);
 

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -11,11 +11,12 @@ export class TaskService {
     return await db.tasks.toArray();
   }
 
-  addTask = async (task: string) => {
+  addTask = async (task: string, color?: string) => {
     const newTask: Task = {
       id: crypto.randomUUID(),
       text: task,
       completed: false,
+      color: color,
       dateAdded: new Date(),
       dateUpdated: new Date(),
     };
@@ -46,5 +47,21 @@ export class TaskService {
       };
       await db.tasks.update(id, updatedTask);
     }
+  };
+
+  // update only the color of the task
+  // ease of use function for future on the frontend Task UI
+  // we still need to add base update functionality for the tasks
+  // but I see myself wanting to easily change the color of tasks without impacting anything else
+  updateTaskColor = async (id: string, color: string) => {
+    const task = await db.tasks.get(id);
+
+    if (task) {
+      const updatedTask = { ...task, color, dateUpdated: new Date() };
+      await db.tasks.update(id, updatedTask);
+      return updatedTask;
+    }
+
+    console.warn(`Task with id ${id} not found - color not updated 😢`);
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tiptap/core": "^2.10.1",
+        "@tiptap/extension-placeholder": "^2.10.3",
         "@tiptap/react": "^2.10.1",
         "@tiptap/starter-kit": "^2.10.1",
         "dexie": "^4.0.10",
@@ -729,6 +730,19 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.10.3.tgz",
+      "integrity": "sha512-0OkwnDLguZgoiJM85cfnOySuMmPUF7qqw7DHQ+c3zwTAYnvzpvqrvpupc+2Zi9GfC1sDgr+Ajrp8imBHa6PHfA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-strike": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tiptap/core": "^2.10.1",
+    "@tiptap/extension-placeholder": "^2.10.3",
     "@tiptap/react": "^2.10.1",
     "@tiptap/starter-kit": "^2.10.1",
     "dexie": "^4.0.10",


### PR DESCRIPTION
- Adds `color` columns on the Notes and Tasks tables 
- Adds `taskNotes` 'join' table to link tasks and notes 
- Updates Notes and Tasks services with `color` additions
- Adds `updated[Task/Note]Color` functions to each service for easy switching functionality (will be used in future UI implementations)

Nothing is reflected on the frontend, though I did add some TODOs to mark where some of those will go. This work primarily focuses on adding that column, and some ways to interact with it. 

It's also important to note that indexdb is not our final destination here. I wanted to build this app in a way where it *works* the whole time I figure out what I really want here. This is something I'm building for myself, because I find that while I LOVE Notion, and I'm sure other note taking/productivity/etc apps are great, most of the time I want something really simple. I'd rather be able to pull up one app, make some notes gets them done, and get some game points from them lol. 