### PR TITLE
feat: task list overhaul

### DIFF
--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTaskStore } from '@/lib/store/task';
+import ColorSelector from './ColorSelector';
 
 /**
  * A component that renders a text input and an "Add" button.
@@ -14,9 +15,10 @@ import { useTaskStore } from '@/lib/store/task';
 const AddTasks = () => {
   const { addTask } = useTaskStore();
   const [taskText, setTaskText] = useState('');
+  const [taskColor, setTaskColor] = useState('green');
 
   const handleAddTask = async () => {
-    await addTask(taskText);
+    await addTask(taskText, taskColor);
     setTaskText('');
     document.getElementById('task')?.focus();
   };
@@ -32,11 +34,7 @@ const AddTasks = () => {
         placeholder="Add a task..."
       />
       {/** TODO: build a Select to choose the task color - string selections like 'red' 'blue' etc */}
-      {/* <select>
-        <option value="red">Red</option>
-        <option value="blue">Blue</option>
-        <option value="green">Green</option>
-      </select> */}
+      <ColorSelector onColorSelect={(color: string) => setTaskColor(color)} />
 
       <button onClick={handleAddTask}>Add</button>
     </div>

--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -33,7 +33,6 @@ const AddTasks = () => {
         className="flex-grow bg-transparent outline-none placeholder-gray-500"
         placeholder="Add a task..."
       />
-      {/** TODO: build a Select to choose the task color - string selections like 'red' 'blue' etc */}
       <ColorSelector onColorSelect={(color: string) => setTaskColor(color)} />
 
       <button onClick={handleAddTask}>Add</button>

--- a/app/components/AddTasks/ColorSelector.tsx
+++ b/app/components/AddTasks/ColorSelector.tsx
@@ -27,7 +27,7 @@ const ColorSelector = ({
   const [selectedColor, setSelectedColor] = useState(COLORS[2].class);
 
   return (
-    <div className="relative">
+    <div className="relative flex items-center">
       <button
         className={`w-6 h-6 rounded-full border focus:outline-none ${selectedColor}`}
         onClick={() => setDropdownOpen(!dropdownOpen)}

--- a/app/components/AddTasks/ColorSelector.tsx
+++ b/app/components/AddTasks/ColorSelector.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+// we'll need to get the current theme from the app store
+//import { useStore } from '@/lib/store/app';
+
+// constant to record colors that map to tailwind tokens
+export const COLORS = [
+  { name: 'red', class: 'bg-red-200' },
+  { name: 'blue', class: 'bg-blue-200' },
+  { name: 'green', class: 'bg-green-200' },
+  { name: 'yellow', class: 'bg-yellow-200' },
+  { name: 'purple', class: 'bg-purple-200' },
+  { name: 'pink', class: 'bg-pink-200' },
+  { name: 'orange', class: 'bg-orange-200' },
+  { name: 'gray', class: 'bg-gray-200' },
+];
+
+const ColorSelector = ({
+  onColorSelect,
+}: {
+  onColorSelect: (color: string) => void;
+}) => {
+  //TODO: create different sets of colors for tasks/notes depending on the theme
+  // const { theme } = useStore();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [selectedColor, setSelectedColor] = useState(COLORS[2].class);
+
+  return (
+    <div className="relative">
+      <button
+        className={`w-6 h-6 rounded-full border focus:outline-none ${selectedColor}`}
+        onClick={() => setDropdownOpen(!dropdownOpen)}
+      ></button>
+      {dropdownOpen && (
+        <div className="absolute left-0 mt-2 bg-white shadow-md rounded-lg p-2 flex flex-wrap gap-2">
+          {COLORS.map((color) => (
+            <div
+              key={color.name}
+              className={`w-8 h-8 rounded-full cursor-pointer border ${color.class}`}
+              onClick={() => {
+                setSelectedColor(color.class);
+                onColorSelect(color.name);
+                setDropdownOpen(false);
+              }}
+            ></div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ColorSelector;

--- a/app/components/AddTasks/ColorSelector.tsx
+++ b/app/components/AddTasks/ColorSelector.tsx
@@ -1,20 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { COLORS } from '@/constants';
 // we'll need to get the current theme from the app store
 //import { useStore } from '@/lib/store/app';
-
-// constant to record colors that map to tailwind tokens
-export const COLORS = [
-  { name: 'red', class: 'bg-red-200' },
-  { name: 'blue', class: 'bg-blue-200' },
-  { name: 'green', class: 'bg-green-200' },
-  { name: 'yellow', class: 'bg-yellow-200' },
-  { name: 'purple', class: 'bg-purple-200' },
-  { name: 'pink', class: 'bg-pink-200' },
-  { name: 'orange', class: 'bg-orange-200' },
-  { name: 'gray', class: 'bg-gray-200' },
-];
 
 const ColorSelector = ({
   onColorSelect,

--- a/app/components/ClientTaskList/SortableTaskItem.tsx
+++ b/app/components/ClientTaskList/SortableTaskItem.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React from 'react';
+import { Task } from '@/lib/db';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { TaskItem } from './TaskItem';
+// SEE DOCS: https://docs.dndkit.com/presets/sortable
+
+/**
+ * A component that renders a single, sortable task list item.
+ * Rendered in the DndContext in ClientTaskList.
+ *
+ * @param {{ task: Task }} props The component props.
+ * @param {Task} props.task The task to render.
+ * @returns {React.ReactElement} A JSX element representing the sortable task list item.
+ */
+const SortableTaskItem = ({ task }: { task: Task }): React.ReactElement => {
+  // useSortable provides utils to make the elements sortable
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: task.id, // unique identifier for the sortable item
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(transform), // applies position changes when the item is dragged
+    transition, // smooths movements
+  };
+
+  // ref={setNodeRef} - fn to connect this element to dnd-kit system, a ref to DOM element to become droppable
+  // style={style} - drag and transition styles
+  // {...attributes} - ARIA attributes
+  // {...listeners} - attach mouse and touch event handlers
+  return (
+    <li ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <TaskItem task={task} />
+    </li>
+  );
+};
+
+export default SortableTaskItem;

--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
 import MeatballMenu from '../MeatballMenu';
+import { COLORS } from '../AddTasks/ColorSelector';
 
 /**
  * A component to render a single task.
@@ -14,8 +15,13 @@ import MeatballMenu from '../MeatballMenu';
  */
 export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
-
   const { deleteTask, toggleComplete } = useTaskStore();
+
+  // get the background color for the task from the color col
+  const bgColor = task.color
+    ? COLORS.find((color) => color.name === task.color)?.class
+    : 'bg-note';
+
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
   };
@@ -29,7 +35,9 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
   ];
 
   return (
-    <li className="flex items-center justify-between p-4 mb-2 bg-note border border-gray-200 rounded-md shadow-sm hover:shadow-md transition-shadow">
+    <li
+      className={`flex items-center justify-between p-4 mb-2 ${bgColor} border border-gray-200 rounded-md shadow-sm hover:shadow-md transition-shadow`}
+    >
       <div className="flex items-center space-x-4">
         <input
           type="checkbox"
@@ -64,7 +72,10 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
 
       <MeatballMenu
         menuOpen={menuOpen}
-        toggleMenu={toggleMenu}
+        toggleMenu={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          toggleMenu();
+        }}
         items={menuItems}
       />
     </li>

--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
 import MeatballMenu from '../MeatballMenu';
-import { COLORS } from '../AddTasks/ColorSelector';
+import { COLORS } from '@/constants';
 
 /**
  * A component to render a single task.

--- a/app/components/MeatballMenu.tsx
+++ b/app/components/MeatballMenu.tsx
@@ -7,7 +7,7 @@ interface MenuItem {
 
 interface MeatballMenuProps {
   menuOpen: boolean;
-  toggleMenu: () => void;
+  toggleMenu: (e: React.MouseEvent) => void;
   items: MenuItem[];
   className?: string;
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import AddTasks from '../components/AddTasks';
+import AddTasks from '../components/AddTasks/AddTasks';
 import ClientTaskList from '../components/ClientTaskList';
 import NoteDisplay from '../components/NoteBoard';
 import TextEditor from '../components/TextEditor';

--- a/constants.ts
+++ b/constants.ts
@@ -1,0 +1,11 @@
+// constant to record colors that map to tailwind tokens
+export const COLORS = [
+  { name: 'red', class: 'bg-red-200' },
+  { name: 'blue', class: 'bg-blue-200' },
+  { name: 'green', class: 'bg-green-200' },
+  { name: 'yellow', class: 'bg-yellow-200' },
+  { name: 'purple', class: 'bg-purple-200' },
+  { name: 'pink', class: 'bg-pink-200' },
+  { name: 'orange', class: 'bg-orange-200' },
+  { name: 'gray', class: 'bg-gray-200' },
+];

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -8,10 +8,13 @@ export class TaskService {
   // create a method to get all tasks
   async getAllTasks() {
     // return all tasks from the database
-    return await db.tasks.toArray();
+    return await db.tasks.orderBy('position').toArray();
   }
 
   addTask = async (task: string, color?: string) => {
+    const lastTask = await db.tasks.orderBy('position').last();
+    const newTaskPosition = lastTask ? lastTask.position + 1 : 1;
+
     const newTask: Task = {
       id: crypto.randomUUID(),
       text: task,
@@ -19,6 +22,7 @@ export class TaskService {
       color: color,
       dateAdded: new Date(),
       dateUpdated: new Date(),
+      position: newTaskPosition,
     };
     await db.tasks.add(newTask);
     return newTask;
@@ -64,5 +68,16 @@ export class TaskService {
     }
 
     console.warn(`Task with id ${id} not found - color not updated 😢`);
+  };
+  // TODO: remove
+  updateTaskDate = async (id: string) => {
+    const task = await db.tasks.get(id);
+    if (!task) return console.warn(`No task with ${id} to update :(`);
+
+    await db.tasks.update(id, { dateUpdated: new Date() });
+  };
+
+  updateTaskPosition = async (id: string, newPosition: number) => {
+    await db.tasks.update(id, { position: newPosition });
   };
 }

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -5,9 +5,10 @@ import { taskService } from '@/lib/services';
 interface TaskStore {
   tasks: Task[];
   fetchTasks: () => Promise<void>;
-  addTask: (task: string) => void;
+  addTask: (task: string, color?: string) => void;
   deleteTask: (id: string) => void;
   toggleComplete: (id: string) => void;
+  reorderTask: (activeId: string, overId: string) => void;
   //TODO:
   // updateTask: (updatedTask: Task) => void;
 }
@@ -27,9 +28,9 @@ export const useTaskStore = create<TaskStore>((set) => ({
    * @param {Task} task The task to add to the store.
    * @returns {void}
    */
-  addTask: async (task: string) => {
+  addTask: async (task: string, color?: string) => {
     // add the task to the dexie database
-    const newTask = await taskService.addTask(task);
+    const newTask = await taskService.addTask(task, color);
     // update the store with the new task
     set((state) => ({
       tasks: [...state.tasks, newTask],
@@ -66,5 +67,54 @@ export const useTaskStore = create<TaskStore>((set) => ({
         return task;
       }),
     }));
+  },
+
+  /**
+   * Reorder a task to the position of another task. This function will update
+   * the position of the task in the Dexie database and then update the store
+   * with the moved task.
+   *
+   * @param {string} activeId The id of the task being dragged.
+   * @param {string} overId The id of the task being hovered over.
+   * @returns {void}
+   */
+  reorderTask: async (activeId, overId) => {
+    const tasks = await taskService.getAllTasks();
+
+    // find index of task being dragged and task being hovered over
+    const activeIndex = tasks.findIndex((task) => task.id === activeId);
+    const overIndex = tasks.findIndex((task) => task.id === overId);
+
+    if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+      return; // no op drag event
+    }
+
+    // reorder the array
+    const [movedTask] = tasks.splice(activeIndex, 1);
+    tasks.splice(overIndex, 0, movedTask);
+
+    // calculate the new position for moved task
+    const prevTask = tasks[overIndex - 1];
+    const nextTask = tasks[overIndex + 1];
+
+    let newPosition;
+
+    if (prevTask && nextTask) {
+      newPosition = (prevTask.position + nextTask.position) / 2;
+    } else if (prevTask) {
+      newPosition = prevTask.position + 1; // Place at the end
+    } else if (nextTask) {
+      newPosition = nextTask.position / 2; // place at the start
+    } else {
+      newPosition = 1; // fallback to place at start
+    }
+
+    await taskService.updateTaskPosition(activeId, newPosition);
+
+    set({
+      tasks: tasks.map((task) =>
+        task.id === activeId ? { ...task, position: newPosition } : task
+      ),
+    });
   },
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "aws-learner",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.2.0",
+        "@dnd-kit/modifiers": "^8.0.0",
+        "@dnd-kit/sortable": "^9.0.0",
         "@tiptap/core": "^2.10.1",
         "@tiptap/extension-placeholder": "^2.10.3",
         "@tiptap/react": "^2.10.1",
@@ -52,6 +55,68 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.2.0.tgz",
+      "integrity": "sha512-KVK/CJmaYGTxTPU6P0+Oy4itgffTUa80B8317sXzfOr1qUzSL29jE7Th11llXiu2haB7B9Glpzo2CDElin+geQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-8.0.0.tgz",
+      "integrity": "sha512-oPZ0JoKtVSK9hVHSBDKG1oCLgnZbpxuH/SMnyDtXkNhn9+SF1+98DlWILFYxIT8faOS/GgfhlNFREmym6oqrEg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.2.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-9.0.0.tgz",
+      "integrity": "sha512-3/9r8Mmba0nKTbo8kPnVSFZKf/VSy94nXZ3aUwzPEh78j/LooQ/EFKRZENak4PHKBkN53mgTF/z+Sd8H+FcAnQ==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.2.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.2.0",
+    "@dnd-kit/modifiers": "^8.0.0",
+    "@dnd-kit/sortable": "^9.0.0",
     "@tiptap/core": "^2.10.1",
     "@tiptap/extension-placeholder": "^2.10.3",
     "@tiptap/react": "^2.10.1",


### PR DESCRIPTION
This work changes up the Task list, adding a few nice-to-have pieces of functionality. 

- Drag-and-drop tasks to rearrange them 
- Add a color for tasks, with the default being green 

To achieve this we made some changes to the DB:

- Tasks get a `position` column, with this column we're using floats so we can use relative positions and avoid shifting the whole Task table too often 
- Tasks and Notes get a `color` column (Notes colors are not implemented)

We've also added [`dnd-kit`](https://docs.dndkit.com/) to implement the drag and drop feature, and that's been *very* nice to work with. The docs are pretty clear and things seem to *just work*. 

## Testing

1. `npm run dev` 
2. Visit localhost, and it's advised you clear the memory for this page 
3. Add tasks
4. Drag them around
5. Tasks should reorder
6. Select colors for tasks before adding 
7. Tasks should be colored as expected 