### PR TITLE
fix: debug missing colors

### DIFF
--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -18,6 +18,8 @@ const AddTasks = () => {
   const [taskColor, setTaskColor] = useState('green');
 
   const handleAddTask = async () => {
+    // TODO: rm log - test for prod
+    console.log('task color: ', taskColor);
     await addTask(taskText, taskColor);
     setTaskText('');
     document.getElementById('task')?.focus();

--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
 import MeatballMenu from '../MeatballMenu';
-import { COLORS } from '@/utils/constants';
+// TODO: was it the pathing? check prod
+import { COLORS } from '../../../utils/constants';
 
 /**
  * A component to render a single task.
@@ -21,6 +22,8 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
   const bgColor = task.color
     ? COLORS.find((color) => color.name === task.color)?.class
     : 'bg-note';
+
+  console.log('task bg color: ', bgColor);
 
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,8 @@ frontend:
         - npm install
     build:
       commands:
+        - npm run clean
+        - npm ci
         - npm run build
   artifacts:
     baseDirectory: .next # Specify where the build output is located

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ export default {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './utils/**/*.{js,ts}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
I'm trying to figure out why colors for the tasks are appearing locally:

<img width="870" alt="image" src="https://github.com/user-attachments/assets/79826db6-93fc-4610-9313-78215c077a18">

But not in the Amplify environment:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/aa7081e4-c1ce-47b5-9975-8bf5c5996876">

I moved the COLORS constant to a file in `utils`:

```
export const COLORS = [
  { name: 'red', class: 'bg-red-200' },
  { name: 'blue', class: 'bg-blue-200' },
  { name: 'green', class: 'bg-green-200' },
  { name: 'yellow', class: 'bg-yellow-200' },
  { name: 'purple', class: 'bg-purple-200' },
  { name: 'pink', class: 'bg-pink-200' },
  { name: 'orange', class: 'bg-orange-200' },
  { name: 'gray', class: 'bg-gray-200' },
];
```

They use existing tailwind color tokens, they should work fine out of the box, and we see the `theme` setup working in the app. 

I did a few things to test here:

- Logging the color at various points when adding a task 
- Update pathing - instead of using @ alias, I updated to use relative pathing
- Add some steps to the build (clearing cache, etc)
- Adding `utils` to the tailwind config