### PR TITLE
Feat link notes to tasks

### DIFF
--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -15,6 +15,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useTaskStore } from '@/lib/store/task';
+import { useNoteStore } from '@/lib/store/note';
 import SortableTaskItem from './SortableTaskItem';
 
 /**
@@ -28,6 +29,10 @@ import SortableTaskItem from './SortableTaskItem';
  */
 const ClientTaskList = (): React.ReactElement => {
   const { tasks, fetchTasks, reorderTask } = useTaskStore();
+  const { isLinking } = useNoteStore();
+  //TODO: better classes - clsx?
+  const listPadding = isLinking ? 'py-2 px-4' : '';
+  const listBorder = isLinking ? 'border-2 border-highlight rounded-lg' : '';
 
   // https://docs.dndkit.com/api-documentation/sensors
   const sensors = useSensors(
@@ -64,7 +69,7 @@ const ClientTaskList = (): React.ReactElement => {
   };
 
   return (
-    <>
+    <div>
       <div className="flex justify-between items-center">
         <h2 className="text-text text-2xl font-bold mb-4">Tasks</h2>
         {/** TODO: Create function to show completed tasks (update list ordering/visibility) */}
@@ -81,14 +86,14 @@ const ClientTaskList = (): React.ReactElement => {
           items={tasks.map((task) => task.id)}
           strategy={verticalListSortingStrategy}
         >
-          <ul>
+          <ul className={`${listPadding} ${listBorder}`}>
             {tasks.map((task) => (
               <SortableTaskItem key={task.id} task={task} />
             ))}
           </ul>
         </SortableContext>
       </DndContext>
-    </>
+    </div>
   );
 };
 

--- a/app/components/ClientTaskList/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
+import { useNoteStore } from '@/lib/store/note';
 import MeatballMenu from '../MeatballMenu';
 import { COLORS } from '@/utils/constants';
 
@@ -17,10 +18,18 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { deleteTask, toggleComplete } = useTaskStore();
 
+  const { setSelectedTaskIds, selectedTaskIds, isLinking } = useNoteStore();
+
   // get the background color for the task from the color col
   const bgColor = task.color
     ? COLORS.find((color) => color.name === task.color)?.class
     : 'bg-note';
+
+  // TODO - better classes - clsx?
+  const borderColor =
+    isLinking && selectedTaskIds.includes(task.id)
+      ? 'border-2 border-highlight'
+      : '';
 
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
@@ -34,16 +43,32 @@ export const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
     },
   ];
 
+  //TODO: clean up this logic - extract?
+  // switcher between using the checkbox during linking
+  // if isLinking is true, then the input action should add the taskId to the selectedTaskIds array
+  // if isLinking is false, then it should toggleComplete
+  const handleCheckboxChange = () => {
+    if (isLinking) {
+      setSelectedTaskIds(task.id);
+    } else {
+      toggleComplete(task.id);
+    }
+  };
+
+  const checked = isLinking
+    ? selectedTaskIds.includes(task.id)
+    : task.completed;
+
   return (
     <li
-      className={`flex items-center justify-between p-4 mb-2 ${bgColor} border border-gray-200 rounded-md shadow-sm hover:shadow-md transition-shadow`}
+      className={`flex items-center justify-between p-4 mb-2 ${bgColor} ${borderColor} rounded-md shadow-sm hover:shadow-md transition-shadow`}
     >
       <div className="flex items-center space-x-4">
         <input
           type="checkbox"
-          checked={task.completed}
+          checked={checked}
           className="form-checkbox h-5 w-5 rounded focus:outline focus:outline-primary"
-          onChange={() => toggleComplete(task.id)}
+          onChange={handleCheckboxChange}
         />
         <span
           className={`text-gray-800 ${task.completed ? 'line-through' : ''}`}

--- a/app/components/NoteBoard/LinkingControls.tsx
+++ b/app/components/NoteBoard/LinkingControls.tsx
@@ -1,15 +1,34 @@
 import { useNoteStore } from '@/lib/store/note';
 
-//TODO: style these
+/**
+ * A component that renders two buttons to confirm or cancel linking a note to a task.
+ *
+ * The component is only rendered if the user is currently linking a note to a task.
+ *
+ * The confirm button calls `confirmLinking` from the note store, and
+ * the cancel button calls `cancelLinking` from the note store.
+ */
 const LinkingControls = () => {
   const { confirmLinking, cancelLinking, isLinking } = useNoteStore();
 
   if (!isLinking) return null;
 
   return (
-    <div className="linking-controls">
-      <button onClick={confirmLinking}>✔ Confirm</button>
-      <button onClick={cancelLinking}>✖ Cancel</button>
+    <div className="flex py-2 gap-2">
+      <button
+        className="w-[50%] text-center font-bold py-2 px-4 rounded-md
+        bg-green-500 hover:bg-green-600 text-white"
+        onClick={confirmLinking}
+      >
+        ✔ Confirm
+      </button>
+      <button
+        className="w-[50%] text-center font-bold py-2 px-4 rounded-md
+        bg-red-500 hover:bg-red-600 text-white"
+        onClick={cancelLinking}
+      >
+        ✖ Cancel
+      </button>
     </div>
   );
 };

--- a/app/components/NoteBoard/LinkingControls.tsx
+++ b/app/components/NoteBoard/LinkingControls.tsx
@@ -1,0 +1,17 @@
+import { useNoteStore } from '@/lib/store/note';
+
+//TODO: style these
+const LinkingControls = () => {
+  const { confirmLinking, cancelLinking, isLinking } = useNoteStore();
+
+  if (!isLinking) return null;
+
+  return (
+    <div className="linking-controls">
+      <button onClick={confirmLinking}>✔ Confirm</button>
+      <button onClick={cancelLinking}>✖ Cancel</button>
+    </div>
+  );
+};
+
+export default LinkingControls;

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -14,7 +14,7 @@ import LinkingControls from './LinkingControls';
  * @returns {React.ReactElement} A JSX element representing the list of notes.
  */
 const NoteBoardDisplay = (): React.ReactElement => {
-  const { notes, fetchNotes } = useNoteStore();
+  const { notes, fetchNotes, isLinking } = useNoteStore();
 
   // TODO: fetch notes differently - not in a useEffect
   useEffect(() => {
@@ -23,8 +23,12 @@ const NoteBoardDisplay = (): React.ReactElement => {
 
   return (
     <>
-      <h2 className="text-text text-2xl font-bold mb-4">Notes</h2>
-      <LinkingControls />
+      {/** if isLinking is true, don't show h2, show the LinkingControls */}
+      {!isLinking && (
+        <h2 className="text-text text-2xl font-bold mb-4">Notes</h2>
+      )}
+      {isLinking && <LinkingControls />}
+
       <div
         className="flex flex-col h-[50vh] md:h-[50vh] sm:h-auto sm:flex-grow 
                  overflow-y-auto bg-secondary

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from 'react';
 import { useNoteStore } from '@/lib/store/note';
 import NoteDisplay from './NoteDisplay';
+import LinkingControls from './LinkingControls';
 
 /**
  * A component that renders a list of notes.
@@ -23,6 +24,7 @@ const NoteBoardDisplay = (): React.ReactElement => {
   return (
     <>
       <h2 className="text-text text-2xl font-bold mb-4">Notes</h2>
+      <LinkingControls />
       <div
         className="flex flex-col h-[50vh] md:h-[50vh] sm:h-auto sm:flex-grow 
                  overflow-y-auto bg-secondary

--- a/app/components/NoteBoard/NoteDisplay.tsx
+++ b/app/components/NoteBoard/NoteDisplay.tsx
@@ -20,7 +20,10 @@ const NoteDisplay = ({
   });
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const { deleteNote } = useNoteStore();
+  const { deleteNote, startLinking, linkingNoteId } = useNoteStore();
+  const isBeingLinked = linkingNoteId === id;
+  const borderColor = isBeingLinked ? 'border-blue-500' : 'border-note';
+  const borderThickness = isBeingLinked ? 'border-4' : 'border-2';
 
   const menuItems = [
     {
@@ -29,11 +32,20 @@ const NoteDisplay = ({
         deleteNote(id);
       },
     },
+    {
+      label: 'Link to Task',
+      onClick: () => {
+        // close the meatball menu
+        setMenuOpen(false);
+        // begin linking
+        startLinking(id);
+      },
+    },
   ];
 
   return (
     <div
-      className="flex border rounded-md bg-note p-4"
+      className={`flex border rounded-md bg-note p-4 ${borderThickness} ${borderColor}`}
       style={{
         justifyContent: 'space-between',
       }}

--- a/app/components/NoteBoard/NoteDisplay.tsx
+++ b/app/components/NoteBoard/NoteDisplay.tsx
@@ -22,7 +22,7 @@ const NoteDisplay = ({
 
   const { deleteNote, startLinking, linkingNoteId } = useNoteStore();
   const isBeingLinked = linkingNoteId === id;
-  const borderColor = isBeingLinked ? 'border-blue-500' : 'border-note';
+  const borderColor = isBeingLinked ? 'border-highlight' : 'border-note';
   const borderThickness = isBeingLinked ? 'border-4' : 'border-2';
 
   const menuItems = [

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,7 +42,7 @@ export default async function VideoPage() {
       px-4 
       "
       >
-        <div>
+        <div className="flex flex-col gap-4">
           <ClientTaskList />
           <AddTasks />
         </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -23,7 +23,7 @@ export default async function VideoPage() {
       <div className="text-text px-4 py-6 flex justify-between">
         <div>
           <p className="text-2xl">
-            {message} <span className="font-bold">User</span>
+            {message} <span className="font-bold">Ash</span>
           </p>
         </div>
         {/** TODO: Make these into links, create a page for each */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,7 @@
   --color-secondary: #046865;
   --color-text: #074846;
   --color-note: #e9f7ee;
+  --color-highlight: #41d070;
 }
 
 .Orchid {
@@ -29,6 +30,7 @@
   --color-secondary: #310d2e;
   --color-text: #efe9e7;
   --color-note: #ecd5ec;
+  --color-highlight: #e766cd;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/lib/services/note.ts
+++ b/lib/services/note.ts
@@ -51,4 +51,18 @@ export class NoteService {
   deleteNote = async (id: string) => {
     await db.notes.delete(id);
   };
+
+  // associate tasks with notes and vice versa
+  // we need to create a fn to add to the taskNotes table
+  // taskNotes: Dexie.Table<{ taskId: string; noteId: string }, [string, string]>;
+  // we can select more than one task per note
+  // should handle in a promise.all fashion
+  addNoteToTask = async (noteId: string, taskIds: string[]) => {
+    const taskNotes = taskIds.map((taskId) => ({
+      taskId,
+      noteId,
+    }));
+
+    await db.taskNotes.bulkAdd(taskNotes);
+  };
 }

--- a/lib/store/note.ts
+++ b/lib/store/note.ts
@@ -4,17 +4,18 @@ import { noteService } from '@/lib/services';
 
 interface NoteStore {
   notes: Note[];
-  fetchNotes: () => Promise<void>;
-  addNote: (content: Record<string, object>) => void;
-  deleteNote: (id: string) => void;
-  // linkNoteToTasks: (id: string, taskIds: string[]) => void;
-
   linkingNoteId: string | null;
   selectedTaskIds: string[];
   isLinking: boolean;
+  // CRUD
+  fetchNotes: () => Promise<void>;
+  addNote: (content: Record<string, object>) => void;
+  deleteNote: (id: string) => void;
+  // Note/Task linking
   cancelLinking: () => void;
   startLinking: (noteId: string) => void;
   confirmLinking: () => void;
+  setSelectedTaskIds: (taskId: string) => void;
 }
 
 export const useNoteStore = create<NoteStore>((set, get) => ({
@@ -49,7 +50,7 @@ export const useNoteStore = create<NoteStore>((set, get) => ({
     set({ linkingNoteId: noteId, selectedTaskIds: [], isLinking: true });
   },
 
-  selectTask: (taskId: string) => {
+  setSelectedTaskIds: (taskId: string) => {
     set((state) => ({
       selectedTaskIds: state.selectedTaskIds.includes(taskId)
         ? state.selectedTaskIds.filter((id) => id !== taskId)

--- a/lib/store/note.ts
+++ b/lib/store/note.ts
@@ -7,10 +7,21 @@ interface NoteStore {
   fetchNotes: () => Promise<void>;
   addNote: (content: Record<string, object>) => void;
   deleteNote: (id: string) => void;
+  // linkNoteToTasks: (id: string, taskIds: string[]) => void;
+
+  linkingNoteId: string | null;
+  selectedTaskIds: string[];
+  isLinking: boolean;
+  cancelLinking: () => void;
+  startLinking: (noteId: string) => void;
+  confirmLinking: () => void;
 }
 
-export const useNoteStore = create<NoteStore>((set) => ({
+export const useNoteStore = create<NoteStore>((set, get) => ({
   notes: [],
+  linkingNoteId: null, // the id of a note being currently linked to Tasks
+  selectedTaskIds: [],
+  isLinking: false, // whether the user is currently linking a note to tasks
 
   fetchNotes: async () => {
     const allNotes = await noteService.getAllNotes();
@@ -31,5 +42,38 @@ export const useNoteStore = create<NoteStore>((set) => ({
     set((state) => ({
       notes: state.notes.filter((task) => task.id !== id),
     }));
+  },
+
+  // linking logics
+  startLinking: (noteId: string) => {
+    set({ linkingNoteId: noteId, selectedTaskIds: [], isLinking: true });
+  },
+
+  selectTask: (taskId: string) => {
+    set((state) => ({
+      selectedTaskIds: state.selectedTaskIds.includes(taskId)
+        ? state.selectedTaskIds.filter((id) => id !== taskId)
+        : [...state.selectedTaskIds, taskId],
+    }));
+  },
+
+  /**
+   * Confirms the linking process.
+   *
+   * If a note is being linked to tasks (i.e. `linkingNoteId` is not null)
+   * and at least one task is selected, this function will link the note
+   * to the selected tasks using the note service, and then
+   * cancel the linking process.
+   */
+  confirmLinking: async () => {
+    const { linkingNoteId, selectedTaskIds, cancelLinking } = get();
+    if (linkingNoteId && selectedTaskIds.length) {
+      await noteService.addNoteToTask(linkingNoteId, selectedTaskIds);
+      cancelLinking();
+    }
+  },
+
+  cancelLinking: () => {
+    set({ linkingNoteId: null, selectedTaskIds: [], isLinking: false });
   },
 }));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,7 @@ export default {
         // custom set up
         primary: 'var(--color-primary)',
         secondary: 'var(--color-secondary)',
+        highlight: 'var(--color-highlight)',
         text: 'var(--color-text)',
         note: 'var(--color-note)', // for the default note bg color
       },


### PR DESCRIPTION

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/ed5085b4-b820-4952-b26a-8e35a74f5cf8" />
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/f635f009-6312-4964-9b4c-d01d703cc278" />

- Updates note store: 
  - Adds 3 more state values to track selected note, selected task ids, and a boolean to track when we're currently linking a note to tasks 
  - Adds functions to update selected task ids
- Updates task list - when we're in a `isLinking` phase, clicking the task checkbox input adds it to the selectedTaskIds in the note store 
- Updates themes and various styles for both current themes 

Testing:

1. npm run dev
2. In the dashboard create a note and several tasks 
3. Click meatball menu on the note and select "Link to Tasks"
4. The UI should update with confirm/cancel buttons 
5. Note should be outlined 
6. Tasks should become outlined 
7. Selecting a task adds a border 
8. Clicking "cancel" should take you out of linking phase - all selections should be cleared 
9. Clicking "confirm" with selected tasks will update the `taskNotes` table in Application -> IndexDb