### PR TITLE
feat: update fetching/persistence of task items

### DIFF
--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   DndContext,
   closestCenter,
@@ -19,16 +19,22 @@ import { useNoteStore } from '@/lib/store/note';
 import SortableTaskItem from './SortableTaskItem';
 
 /**
- * A component that renders a list of tasks.
+ * A component that renders a draggable and sortable list of tasks.
  *
- * It utilizes the `useTaskStore` hook to access and fetch tasks from the store.
- * On component mount, it triggers the `fetchTasks` function to load tasks.
- * Each task is rendered as a `TaskItem` within an unordered list.
+ * It utilizes the DndContext and SortableContext from the dnd-kit library
+ * to provide drag-and-drop functionality. Tasks can be reordered by dragging.
  *
- * @returns {React.ReactElement} A JSX element representing the list of tasks.
+ * The component listens to drag-end events to update the order of tasks
+ * using the reorderTask function from the task store.
+ *
+ * The appearance of the task list can change depending on whether the user is
+ * linking tasks to a note, adding specific padding and borders.
+ *
+ * @returns {React.ReactElement} A JSX element representing the task list.
  */
+
 const ClientTaskList = (): React.ReactElement => {
-  const { tasks, fetchTasks, reorderTask } = useTaskStore();
+  const { tasks, reorderTask } = useTaskStore();
   const { isLinking } = useNoteStore();
   //TODO: better classes - clsx?
   const listPadding = isLinking ? 'py-2 px-4' : '';
@@ -49,11 +55,6 @@ const ClientTaskList = (): React.ReactElement => {
     })
   );
 
-  // TODO: fetch tasks differently - not in a useEffect
-  useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
-
   // dnd setup
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -62,9 +63,6 @@ const ClientTaskList = (): React.ReactElement => {
 
     if (active.id !== over.id) {
       reorderTask(String(active.id), String(over.id));
-
-      // Refetch tasks
-      await fetchTasks();
     }
   };
 

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { Task } from '@/lib/db';
 import { taskService } from '@/lib/services';
 
@@ -13,108 +14,108 @@ interface TaskStore {
   // updateTask: (updatedTask: Task) => void;
 }
 
-export const useTaskStore = create<TaskStore>((set) => ({
-  tasks: [],
-
-  fetchTasks: async () => {
-    const allTasks = await taskService.getAllTasks();
-    set({ tasks: allTasks });
-  },
-
-  /**
-   * Add a new task to the store. This function will add the task to the dexie
-   * database and then update the store with the new task.
-   *
-   * @param {Task} task The task to add to the store.
-   * @returns {void}
-   */
-  addTask: async (task: string, color?: string) => {
-    // add the task to the dexie database
-    const newTask = await taskService.addTask(task, color);
-    // update the store with the new task
-    set((state) => ({
-      tasks: [...state.tasks, newTask],
-    }));
-  },
-
-  /**
-   * Remove a task from the store. This function will delete the task from the
-   * Dexie database and then update the store without the task.
-   *
-   * @param {string} id The id of the task to remove from the store.
-   * @returns {void}
-   */
-  deleteTask: async (id: string) => {
-    // remove the task from the dexie database
-    await taskService.deleteTask(id);
-    // update the store with the new task
-    set((state) => ({
-      tasks: state.tasks.filter((task) => task.id !== id),
-    }));
-  },
-
-  // toggle task completion
-  toggleComplete: async (id: string) => {
-    // update the task in the dexie database
-    await taskService.toggleComplete(id);
-    // update the store with the new task
-    // what would be a more direct way to update this? get the task back from the dexie database and use that?
-    set((state) => ({
-      tasks: state.tasks.map((task) => {
-        if (task.id === id) {
-          return { ...task, completed: !task.completed };
+export const useTaskStore = create<TaskStore>()(
+  persist(
+    (set) => ({
+      tasks: [],
+      fetchTasks: async () => {
+        try {
+          const allTasks = await taskService.getAllTasks();
+          set({ tasks: allTasks });
+        } catch (error) {
+          console.error('Failed to fetch tasks:', error);
         }
-        return task;
-      }),
-    }));
-  },
+      },
+      addTask: async (text, color) => {
+        const newTask = await taskService.addTask(text, color);
+        set((state) => ({ tasks: [...state.tasks, newTask] }));
+      },
+      toggleComplete: async (id) => {
+        await taskService.toggleComplete(id);
+        set((state) => ({
+          tasks: state.tasks.map((task) =>
+            task.id === id ? { ...task, completed: !task.completed } : task
+          ),
+        }));
+      },
+      deleteTask: async (id) => {
+        await taskService.deleteTask(id);
+        set((state) => ({
+          tasks: state.tasks.filter((task) => task.id !== id),
+        }));
+      },
+      /**
+       * Reorder a task to the position of another task. This function will update
+       * the position of the task in the Dexie database and then update the store
+       * with the moved task.
+       *
+       * @param {string} activeId The id of the task being dragged.
+       * @param {string} overId The id of the task being hovered over.
+       * @returns {void}
+       */
+      reorderTask: async (activeId, overId) => {
+        const tasks = await taskService.getAllTasks();
 
-  /**
-   * Reorder a task to the position of another task. This function will update
-   * the position of the task in the Dexie database and then update the store
-   * with the moved task.
-   *
-   * @param {string} activeId The id of the task being dragged.
-   * @param {string} overId The id of the task being hovered over.
-   * @returns {void}
-   */
-  reorderTask: async (activeId, overId) => {
-    const tasks = await taskService.getAllTasks();
+        // find index of task being dragged and task being hovered over
+        const activeIndex = tasks.findIndex((task) => task.id === activeId);
+        const overIndex = tasks.findIndex((task) => task.id === overId);
 
-    // find index of task being dragged and task being hovered over
-    const activeIndex = tasks.findIndex((task) => task.id === activeId);
-    const overIndex = tasks.findIndex((task) => task.id === overId);
+        if (
+          activeIndex === -1 ||
+          overIndex === -1 ||
+          activeIndex === overIndex
+        ) {
+          return; // no op drag event
+        }
 
-    if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
-      return; // no op drag event
+        // reorder the array
+        const [movedTask] = tasks.splice(activeIndex, 1);
+        tasks.splice(overIndex, 0, movedTask);
+
+        // calculate the new position for moved task
+        const prevTask = tasks[overIndex - 1];
+        const nextTask = tasks[overIndex + 1];
+
+        let newPosition;
+
+        if (prevTask && nextTask) {
+          newPosition = (prevTask.position + nextTask.position) / 2;
+        } else if (prevTask) {
+          newPosition = prevTask.position + 1; // Place at the end
+        } else if (nextTask) {
+          newPosition = nextTask.position / 2; // place at the start
+        } else {
+          newPosition = 1; // fallback to place at start
+        }
+
+        await taskService.updateTaskPosition(activeId, newPosition);
+
+        set({
+          tasks: tasks.map((task) =>
+            task.id === activeId ? { ...task, position: newPosition } : task
+          ),
+        });
+      },
+    }),
+    {
+      name: 'task-store',
+      /**
+       * Rehydrates the tasks store by fetching all tasks from the database and
+       * saving them to the store.
+       *
+       * This function is called when the store is rehydrated from local storage.
+       * It ensures that the tasks store is always up to date with the database.
+       *
+       * read more: https://zustand.docs.pmnd.rs/integrations/persisting-store-data
+       */
+      onRehydrateStorage: () => async (state) => {
+        // Defer accessing `useTaskStore` to avoid circular reference
+        //TODO: this is a hack, there's probably a better way
+        if (state) {
+          const fetchTasks = state.fetchTasks;
+          await fetchTasks();
+        }
+      },
     }
-
-    // reorder the array
-    const [movedTask] = tasks.splice(activeIndex, 1);
-    tasks.splice(overIndex, 0, movedTask);
-
-    // calculate the new position for moved task
-    const prevTask = tasks[overIndex - 1];
-    const nextTask = tasks[overIndex + 1];
-
-    let newPosition;
-
-    if (prevTask && nextTask) {
-      newPosition = (prevTask.position + nextTask.position) / 2;
-    } else if (prevTask) {
-      newPosition = prevTask.position + 1; // Place at the end
-    } else if (nextTask) {
-      newPosition = nextTask.position / 2; // place at the start
-    } else {
-      newPosition = 1; // fallback to place at start
-    }
-
-    await taskService.updateTaskPosition(activeId, newPosition);
-
-    set({
-      tasks: tasks.map((task) =>
-        task.id === activeId ? { ...task, position: newPosition } : task
-      ),
-    });
-  },
-}));
+  )
+);


### PR DESCRIPTION
## Changes 

- Adds a `persist` configuration (from zustand) to the `taskStore` - combining immediate and deferred state management 
- Removes usage of `fetchTasks` in ClientTaskList component 

Flow looks a little like:

1. Initial Load - Zustand initializes the store.
2. `persist` checks the storage for saved state (task-store in localStorage or another medium)
3. If saved state exists, it’s loaded into the store.
4. `onRehydrateStorage` runs, and fetchTasks updates the store with fresh data from IndexedDB.

During Usage:
- User adds/updates/deletes tasks, which triggers state changes in the store.
- `persist` saves the updated state to storage.

Page Reload:
- The persisted state is loaded from storage to populate the store immediately
- `onRehydrateStorage` runs to ensure the in-memory state is fresh by fetching tasks from IndexedDB

https://zustand.docs.pmnd.rs/integrations/persisting-store-data

I made this choice because I wanted to get some hands-on experience with `persist`, and because I want the updates to feel very snappy as the user is adding, updating, arranging, etc the tasks and notes in their dashboard, relying on in-memory state that gets hydrated from the database at regular intervals. 
