### PR TITLE
feat: Adds note reordering

### DIFF
--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -15,7 +15,6 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useNoteStore } from '@/lib/store/note';
-// import NoteDisplay from './NoteDisplay';
 import SortableNoteDisplay from './SortableNoteDisplay';
 import LinkingControls from './LinkingControls';
 
@@ -31,7 +30,6 @@ import LinkingControls from './LinkingControls';
  *
  * @returns {React.ReactElement} A JSX element representing the note board display.
  */
-
 const NoteBoardDisplay = (): React.ReactElement => {
   const { notes, isLinking, reorderNote } = useNoteStore();
 

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -1,8 +1,22 @@
 'use client';
 
 import React, { useEffect } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  DragEndEvent,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  TouchSensor,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { useNoteStore } from '@/lib/store/note';
-import NoteDisplay from './NoteDisplay';
+// import NoteDisplay from './NoteDisplay';
+import SortableNoteDisplay from './SortableNoteDisplay';
 import LinkingControls from './LinkingControls';
 
 /**
@@ -14,7 +28,31 @@ import LinkingControls from './LinkingControls';
  * @returns {React.ReactElement} A JSX element representing the list of notes.
  */
 const NoteBoardDisplay = (): React.ReactElement => {
-  const { notes, fetchNotes, isLinking } = useNoteStore();
+  const { notes, fetchNotes, isLinking, reorderNote } = useNoteStore();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250, // ms delay
+        tolerance: 5,
+      },
+    })
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over) return;
+
+    if (active.id !== over.id) {
+      reorderNote(String(active.id), String(over.id));
+    }
+  };
 
   // TODO: fetch notes differently - not in a useEffect
   useEffect(() => {
@@ -23,7 +61,7 @@ const NoteBoardDisplay = (): React.ReactElement => {
 
   return (
     <>
-      {/** if isLinking is true, don't show h2, show the LinkingControls */}
+      {/** if isLinking is true, don't show h2, show the LinkingControls buttons */}
       {!isLinking && (
         <h2 className="text-text text-2xl font-bold mb-4">Notes</h2>
       )}
@@ -34,11 +72,23 @@ const NoteBoardDisplay = (): React.ReactElement => {
                  overflow-y-auto bg-secondary
                  p-4 rounded shadow-md"
       >
-        <ul className="space-y-4">
-          {notes.map((note) => (
-            <NoteDisplay key={note.id} id={note.id} content={note.content} />
-          ))}
-        </ul>
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          sensors={sensors}
+        >
+          <SortableContext
+            items={notes.map((note) => note.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="space-y-4">
+              {notes.map((note) => (
+                <SortableNoteDisplay key={note.id} note={note} />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+
         {notes.length === 0 && (
           <p className="text-text text-center bg-note w-[60%] mx-auto my-auto rounded-sm py-4 px-4">
             No current notes to display{' '}

--- a/app/components/NoteBoard/NoteBoard.tsx
+++ b/app/components/NoteBoard/NoteBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   DndContext,
   closestCenter,
@@ -20,15 +20,20 @@ import SortableNoteDisplay from './SortableNoteDisplay';
 import LinkingControls from './LinkingControls';
 
 /**
- * A component that renders a list of notes.
+ * A component that renders a draggable and sortable list of notes.
  *
- * It fetches the notes from the store when mounted.
- * Each note is rendered as a `NoteDisplay` component within an unordered list.
+ * Utilizes the DndContext and SortableContext from the dnd-kit library
+ * to provide drag-and-drop functionality for notes, allowing reordering
+ * by dragging.
  *
- * @returns {React.ReactElement} A JSX element representing the list of notes.
+ * Displays a header or linking controls based on the linking state,
+ * managed by the note store.
+ *
+ * @returns {React.ReactElement} A JSX element representing the note board display.
  */
+
 const NoteBoardDisplay = (): React.ReactElement => {
-  const { notes, fetchNotes, isLinking, reorderNote } = useNoteStore();
+  const { notes, isLinking, reorderNote } = useNoteStore();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -53,11 +58,6 @@ const NoteBoardDisplay = (): React.ReactElement => {
       reorderNote(String(active.id), String(over.id));
     }
   };
-
-  // TODO: fetch notes differently - not in a useEffect
-  useEffect(() => {
-    fetchNotes();
-  }, [fetchNotes]);
 
   return (
     <>

--- a/app/components/NoteBoard/SortableNoteDisplay.tsx
+++ b/app/components/NoteBoard/SortableNoteDisplay.tsx
@@ -15,7 +15,6 @@ import NoteDisplay from './NoteDisplay';
  * @param {Note} props.note The note to render.
  * @returns {React.ReactElement} A JSX element representing the sortable note list item.
  */
-
 const SortableNoteDisplay = ({ note }: { note: Note }): React.ReactElement => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({

--- a/app/components/NoteBoard/SortableNoteDisplay.tsx
+++ b/app/components/NoteBoard/SortableNoteDisplay.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Note } from '@/lib/db';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import NoteDisplay from './NoteDisplay';
+
+/**
+ * A component that renders a single, sortable note list item.
+ * Utilizes the `useSortable` hook from the dnd-kit library to provide
+ * drag-and-drop functionality for notes within a list.
+ *
+ * @param {{ note: Note }} props The component props.
+ * @param {Note} props.note The note to render.
+ * @returns {React.ReactElement} A JSX element representing the sortable note list item.
+ */
+
+const SortableNoteDisplay = ({ note }: { note: Note }): React.ReactElement => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: note.id,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <NoteDisplay id={note.id} content={note.content} />
+    </li>
+  );
+};
+
+export default SortableNoteDisplay;

--- a/lib/services/note.ts
+++ b/lib/services/note.ts
@@ -8,7 +8,6 @@ export class NoteService {
   async getAllNotes() {
     return await db.notes.toArray();
   }
-
   addNote = async (content: Record<string, object>, color?: string) => {
     // get the last note and its position, add a new note right after
     const lastNote = await db.notes.orderBy('position').last();
@@ -26,14 +25,12 @@ export class NoteService {
     await db.notes.add(note);
     return note;
   };
-
   updateNote = async (note: Note) => {
     // get the note, and add a time stamp, and add the task to the database
     const updatedNote = { ...note, dateUpdated: new Date() };
     await db.tasks.update(note.id, updatedNote);
     return updatedNote;
   };
-
   /**
    * Update the color of a note background in the UI
    * @param {string} id - The id of the task to update
@@ -52,16 +49,9 @@ export class NoteService {
       `Note with id ${id} could not be found - color not updated 😢`
     );
   };
-
   deleteNote = async (id: string) => {
     await db.notes.delete(id);
   };
-
-  // associate tasks with notes and vice versa
-  // we need to create a fn to add to the taskNotes table
-  // taskNotes: Dexie.Table<{ taskId: string; noteId: string }, [string, string]>;
-  // we can select more than one task per note
-  // should handle in a promise.all fashion
   addNoteToTask = async (noteId: string, taskIds: string[]) => {
     const taskNotes = taskIds.map((taskId) => ({
       taskId,
@@ -69,5 +59,8 @@ export class NoteService {
     }));
 
     await db.taskNotes.bulkAdd(taskNotes);
+  };
+  updateNotePosition = async (id: string, newPosition: number) => {
+    await db.notes.update(id, { position: newPosition });
   };
 }

--- a/lib/services/note.ts
+++ b/lib/services/note.ts
@@ -6,7 +6,7 @@ import { db, Note } from '../db';
 
 export class NoteService {
   async getAllNotes() {
-    return await db.notes.toArray();
+    return await db.notes.orderBy('position').toArray();
   }
   addNote = async (content: Record<string, object>, color?: string) => {
     // get the last note and its position, add a new note right after

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -10,7 +10,6 @@ export class TaskService {
     // return all tasks from the database
     return await db.tasks.orderBy('position').toArray();
   }
-
   addTask = async (task: string, color?: string) => {
     const lastTask = await db.tasks.orderBy('position').last();
     const newTaskPosition = lastTask ? lastTask.position + 1 : 1;
@@ -27,19 +26,16 @@ export class TaskService {
     await db.tasks.add(newTask);
     return newTask;
   };
-
   updateTask = async (task: Task) => {
     // get the task, and add a time stamp, and add the task to the database
     const updatedTask = { ...task, dateUpdated: new Date() };
     await db.tasks.update(task.id, updatedTask);
     return updatedTask;
   };
-
   deleteTask = async (id: string) => {
     // delete the task from the database
     await db.tasks.delete(id);
   };
-
   toggleComplete = async (id: string) => {
     const task = await db.tasks.get(id);
 
@@ -52,7 +48,6 @@ export class TaskService {
       await db.tasks.update(id, updatedTask);
     }
   };
-
   /**
    * Update the color of a task background in the UI
    * @param {string} id - The id of the task to update
@@ -76,7 +71,6 @@ export class TaskService {
 
     await db.tasks.update(id, { dateUpdated: new Date() });
   };
-
   updateTaskPosition = async (id: string, newPosition: number) => {
     await db.tasks.update(id, { position: newPosition });
   };

--- a/lib/store/note.ts
+++ b/lib/store/note.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { Note } from '@/lib/db';
 import { noteService } from '@/lib/services';
 
@@ -19,105 +20,122 @@ interface NoteStore {
   setSelectedTaskIds: (taskId: string) => void;
 }
 
-export const useNoteStore = create<NoteStore>((set, get) => ({
-  notes: [],
-  linkingNoteId: null, // the id of a note being currently linked to Tasks
-  selectedTaskIds: [],
-  isLinking: false, // whether the user is currently linking a note to tasks
+export const useNoteStore = create<NoteStore>()(
+  persist(
+    (set, get) => ({
+      notes: [],
+      linkingNoteId: null, // the id of a note being currently linked to Tasks
+      selectedTaskIds: [],
+      isLinking: false, // whether the user is currently linking a note to tasks
 
-  fetchNotes: async () => {
-    const allNotes = await noteService.getAllNotes();
-    set({ notes: allNotes });
-  },
-  addNote: async (content: Record<string, object>, color?: string) => {
-    const newNote = await noteService.addNote(content, color);
+      fetchNotes: async () => {
+        const allNotes = await noteService.getAllNotes();
+        set({ notes: allNotes });
+      },
+      addNote: async (content: Record<string, object>, color?: string) => {
+        const newNote = await noteService.addNote(content, color);
 
-    set((state) => ({
-      notes: [...state.notes, newNote],
-    }));
-  },
-  deleteNote: async (id: string) => {
-    await noteService.deleteNote(id);
+        set((state) => ({
+          notes: [...state.notes, newNote],
+        }));
+      },
+      deleteNote: async (id: string) => {
+        await noteService.deleteNote(id);
 
-    set((state) => ({
-      notes: state.notes.filter((task) => task.id !== id),
-    }));
-  },
-  /**
-   * Reorder a note to the position of another note. This function will update
-   * the position of the note in the Dexie database and then update the store
-   * with the moved note.
-   *
-   * @param {string} activeId The id of the note being dragged.
-   * @param {string} overId The id of the note being hovered over.
-   * @returns {void}
-   */
-  reorderNote: async (activeId, overId) => {
-    const notes = await noteService.getAllNotes();
+        set((state) => ({
+          notes: state.notes.filter((task) => task.id !== id),
+        }));
+      },
+      /**
+       * Reorder a note to the position of another note. This function will update
+       * the position of the note in the Dexie database and then update the store
+       * with the moved note.
+       *
+       * @param {string} activeId The id of the note being dragged.
+       * @param {string} overId The id of the note being hovered over.
+       * @returns {void}
+       */
+      reorderNote: async (activeId, overId) => {
+        const notes = await noteService.getAllNotes();
 
-    // find index of task being dragged and task being hovered over
-    const activeIndex = notes.findIndex((note) => note.id === activeId);
-    const overIndex = notes.findIndex((note) => note.id === overId);
+        // find index of task being dragged and task being hovered over
+        const activeIndex = notes.findIndex((note) => note.id === activeId);
+        const overIndex = notes.findIndex((note) => note.id === overId);
 
-    if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
-      return; // no op drag event
+        if (
+          activeIndex === -1 ||
+          overIndex === -1 ||
+          activeIndex === overIndex
+        ) {
+          return; // no op drag event
+        }
+
+        // reorder the array
+        const [movedNote] = notes.splice(activeIndex, 1);
+        notes.splice(overIndex, 0, movedNote);
+
+        // calculate the new position for moved task
+        const prevNote = notes[overIndex - 1];
+        const nextNote = notes[overIndex + 1];
+
+        let newPosition;
+
+        if (prevNote && nextNote) {
+          newPosition = (prevNote.position + nextNote.position) / 2;
+        } else if (prevNote) {
+          newPosition = prevNote.position + 1; // Place at the end
+        } else if (nextNote) {
+          newPosition = nextNote.position / 2; // place at the start
+        } else {
+          newPosition = 1; // fallback to place at start
+        }
+
+        await noteService.updateNotePosition(activeId, newPosition);
+
+        set({
+          notes: notes.map((note) =>
+            note.id === activeId ? { ...note, position: newPosition } : note
+          ),
+        });
+      },
+      /* ------------------------------ LINKING LOGIC ----------------------------- */
+      startLinking: (noteId: string) => {
+        set({ linkingNoteId: noteId, selectedTaskIds: [], isLinking: true });
+      },
+      setSelectedTaskIds: (taskId: string) => {
+        set((state) => ({
+          selectedTaskIds: state.selectedTaskIds.includes(taskId)
+            ? state.selectedTaskIds.filter((id) => id !== taskId)
+            : [...state.selectedTaskIds, taskId],
+        }));
+      },
+      /**
+       * Confirms the linking process.
+       *
+       * If a note is being linked to tasks (i.e. `linkingNoteId` is not null)
+       * and at least one task is selected, this function will link the note
+       * to the selected tasks using the note service, and then
+       * cancel the linking process.
+       */
+      confirmLinking: async () => {
+        const { linkingNoteId, selectedTaskIds, cancelLinking } = get();
+        if (linkingNoteId && selectedTaskIds.length) {
+          await noteService.addNoteToTask(linkingNoteId, selectedTaskIds);
+          cancelLinking();
+        }
+      },
+      cancelLinking: () => {
+        set({ linkingNoteId: null, selectedTaskIds: [], isLinking: false });
+      },
+    }),
+    {
+      name: 'note-store',
+      onRehydrateStorage: () => async (state) => {
+        if (state) {
+          const fetchNotes = state.fetchNotes;
+          await fetchNotes();
+        }
+      },
     }
-
-    // reorder the array
-    const [movedNote] = notes.splice(activeIndex, 1);
-    notes.splice(overIndex, 0, movedNote);
-
-    // calculate the new position for moved task
-    const prevNote = notes[overIndex - 1];
-    const nextNote = notes[overIndex + 1];
-
-    let newPosition;
-
-    if (prevNote && nextNote) {
-      newPosition = (prevNote.position + nextNote.position) / 2;
-    } else if (prevNote) {
-      newPosition = prevNote.position + 1; // Place at the end
-    } else if (nextNote) {
-      newPosition = nextNote.position / 2; // place at the start
-    } else {
-      newPosition = 1; // fallback to place at start
-    }
-
-    await noteService.updateNotePosition(activeId, newPosition);
-
-    set({
-      notes: notes.map((task) =>
-        task.id === activeId ? { ...task, position: newPosition } : task
-      ),
-    });
-  },
-  /* ------------------------------ LINKING LOGIC ----------------------------- */
-  startLinking: (noteId: string) => {
-    set({ linkingNoteId: noteId, selectedTaskIds: [], isLinking: true });
-  },
-  setSelectedTaskIds: (taskId: string) => {
-    set((state) => ({
-      selectedTaskIds: state.selectedTaskIds.includes(taskId)
-        ? state.selectedTaskIds.filter((id) => id !== taskId)
-        : [...state.selectedTaskIds, taskId],
-    }));
-  },
-  /**
-   * Confirms the linking process.
-   *
-   * If a note is being linked to tasks (i.e. `linkingNoteId` is not null)
-   * and at least one task is selected, this function will link the note
-   * to the selected tasks using the note service, and then
-   * cancel the linking process.
-   */
-  confirmLinking: async () => {
-    const { linkingNoteId, selectedTaskIds, cancelLinking } = get();
-    if (linkingNoteId && selectedTaskIds.length) {
-      await noteService.addNoteToTask(linkingNoteId, selectedTaskIds);
-      cancelLinking();
-    }
-  },
-  cancelLinking: () => {
-    set({ linkingNoteId: null, selectedTaskIds: [], isLinking: false });
-  },
-}));
+  )
+);


### PR DESCRIPTION
## Changes 

Gives `Notes` a similar treatment to the `Tasks`: 
- `persist` middleware added to the `useNoteStore` to persist our store state in-memory 
- Adds `reorderNote` fn to note service and store 
- Adds dnd-kit setup to the `NoteBoard` and adds `SortableNoteDisplay` wrapper for the `NoteDisplay` 
- Removes `useEffect` and usage of `fetchNotes` in UI 
- Notes can now be reordered as desired 