### PR TITLE
feat: cleaner themes

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,43 +1,23 @@
-'use client';
-import { useStore, Theme } from '@/lib/store/app';
+import ThemeSwitcher from './ThemeSwitcher';
 
 /**
- * A header component that renders a navigation bar with a theme selector and a view selector.
+ * The top-level header component, which displays the app title and selectors
+ * for the theme and view.
  *
- * It uses the `useStore` hook to access the state of the application, AppState
- *
- * The theme selector allows users to switch between a light and dark theme
- * The view selector allows users to switch between viewing tasks and notes, or both
- *
- * View selector is disabled for now, as the logic is not implemented yet
+ * The theme selector is a dropdown menu that allows the user to select
+ * between different color themes. The view selector is a dropdown menu
+ * that allows the user to select between different views: "Tasks & Notes"
+ * (the default), "Tasks Only", and "Notes Only".
  *
  * @returns {JSX.Element} The JSX element representing the header.
  */
 function Header(): JSX.Element {
-  const { theme, setTheme } = useStore(); // Zustand selectors.
-
-  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    //TODO: type research needed:
-    const theme = e.target.value as Theme; // type casting - not sure if this is the best way
-    setTheme(theme);
-  };
-
   return (
     <header className="sticky top-0 bg-primary p-4 px-6 shadow-md flex justify-between items-center z-10">
       <h1 className="text-lg font-bold text-text">HabitNest</h1>
       <div className="flex items-center space-x-4">
-        {/* Theme Selector */}
-        <select
-          value={theme}
-          onChange={handleThemeChange}
-          className="text-gray-900 p-2 rounded"
-        >
-          <option value="Tidepool">Tidepool</option>
-          <option value="Orchid">Orchid</option>
-          {/* <option value="custom">Custom</option> */}
-        </select>
-
-        {/* View Selector */}
+        <ThemeSwitcher />
+        {/* TODO: View Selector */}
         {/* <select
           value={view}
           onChange={(e) => setView(e.target.value)}

--- a/app/components/layout/ThemeSwitcher.tsx
+++ b/app/components/layout/ThemeSwitcher.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+import { useStore } from '@/lib/store/app';
+import { Theme, THEMES, AVAILABLE_THEMES } from '@/lib/core/theme.config';
+
+/**
+ * A dropdown menu that allows the user to select a theme for the app.
+ *
+ * It uses the useStore hook to get the current theme and setTheme function
+ * from the app store. The component listens to the value of the theme
+ * and updates the app store when the value changes.
+ *
+ * @returns {JSX.Element} A JSX element representing the theme switcher.
+ */
+const ThemeSwitcher = (): JSX.Element => {
+  const { theme, setTheme } = useStore();
+
+  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const theme = e.target.value as Theme;
+    setTheme(theme);
+  };
+
+  return (
+    <select
+      value={theme}
+      onChange={handleThemeChange}
+      className="text-gray-900 p-2 rounded"
+    >
+      {AVAILABLE_THEMES.map((theme) => (
+        <option key={theme} value={theme}>
+          {THEMES[theme]}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default ThemeSwitcher;

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,13 +24,33 @@
 }
 
 .Orchid {
-  --background: #332d34;
+  --background: #1a171b;
   --foreground: #f4f7f5;
-  --color-primary: #52154e;
-  --color-secondary: #310d2e;
+  --color-primary: #61195c;
+  --color-secondary: #42113e;
   --color-text: #efe9e7;
   --color-note: #ecd5ec;
   --color-highlight: #e766cd;
+}
+
+.Jewel {
+  --background: #faf8f7;
+  --foreground: #ffffff;
+  --color-primary: #7e57c2;
+  --color-secondary: #26c6da;
+  --color-text: #37474f;
+  --color-note: #e0f7fa;
+  --color-highlight: #ff376c;
+}
+
+.DeepSpace {
+  --background: #0d1b2a;
+  --foreground: #1b263b;
+  --color-primary: #3c51cb;
+  --color-secondary: #7b42dd;
+  --color-text: #c5cbe3;
+  --color-note: #ccb6f1;
+  --color-highlight: #9c27b0;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/lib/core/README.md
+++ b/lib/core/README.md
@@ -1,0 +1,33 @@
+# Core Directory
+
+The **core** directory is intended to house the fundamental pieces of our application's logic. It serves as the backbone of the app, providing essential configurations and utilities that are used throughout the project.
+
+## Key Features
+
+- **Theme Management**: This directory includes configuration and logic related to theme management, allowing for consistent styling and theming across the application.
+- **Centralized Configurations**: Any core configurations that are critical for application functionality reside here, ensuring they are easily accessible and maintainable.
+- **Utility Functions**: Fundamental utility functions that support various components and features of the app are also centralized within this directory.
+
+---
+
+## Adding to the Theme
+
+To add a new theme to the app, the following steps should be taken:
+
+1. In `globals.css`, add a new class definition for the theme, using the theme name:
+
+```
+.Tidepool {
+  --background: #f4f7f5;
+  --foreground: #f4f7f5;
+  --color-primary: #21a0a0;
+  --color-secondary: #046865;
+  --color-text: #074846;
+  --color-note: #e9f7ee;
+  --color-highlight: #41d070;
+}
+```
+
+2. In `lib/core/theme.config.ts`, add the new theme to the `THEMES` array.
+
+With that the new theme will be available for selection through the `Header` component.

--- a/lib/core/theme.config.ts
+++ b/lib/core/theme.config.ts
@@ -1,0 +1,18 @@
+/**
+ * This module contains constants related to the themes (colors) of the application.
+ *
+ * @module theme.config
+ */
+
+export const THEMES = {
+  Tidepool: 'Tidepool',
+  Orchid: 'Orchid',
+  Jewel: 'Jewel',
+  DeepSpace: 'DeepSpace',
+};
+
+export type Theme = keyof typeof THEMES;
+
+export const DEFAULT_THEME: Theme = 'Tidepool';
+
+export const AVAILABLE_THEMES: Theme[] = Object.keys(THEMES) as Theme[];

--- a/lib/store/app.ts
+++ b/lib/store/app.ts
@@ -1,11 +1,5 @@
 import { create } from 'zustand';
-
-// export enum Theme {
-//   Light = 'light',
-//   Dark = 'dark',
-// }
-// change theme to names
-export type Theme = 'Tidepool' | 'Orchid';
+import { DEFAULT_THEME, Theme, THEMES } from '../core/theme.config';
 
 interface AppState {
   view: {
@@ -30,19 +24,12 @@ export const useStore = create<AppState>((set) => ({
       },
     }));
   },
-  theme: 'Tidepool',
-  // setTheme: (theme: Theme) => {
-  //   set(() => ({ theme }));
-  //   // update <html> class for Tailwind dark mode
-  //   if (typeof document !== 'undefined') {
-  //     document.documentElement.classList.toggle('dark', theme === 'dark');
-  //   }
-  // },
+  theme: DEFAULT_THEME,
   setTheme: (theme: Theme) => {
     set(() => ({ theme }));
 
     if (typeof document !== 'undefined') {
-      document.documentElement.classList.remove('Tidepool', 'Orchid');
+      document.documentElement.classList.remove(...Object.keys(THEMES));
       document.documentElement.classList.add(theme);
     }
   },


### PR DESCRIPTION
## Changes 

- Introduced a THEMES object to define available themes as a single source of truth.
- Simplifies the process of adding new themes (just update THEMES and global.css).
- Prevents duplication of theme names across files.
- Adds 2 new themes - Jewel and Deep Space 
- Updates app store (zustand store) to use new Theme types and constants 
- Adds `ThemeSwitcher` component and consumes in the `Header` 

This will make adding new themes much easier (just update the THEMES config and globals.css), with no need to update the `select` or ThemeSwitcher component. It's also a pattern I'd like to use more as I continue fleshing out what the heck this app is. 