### PR TITLE
fix: prod envs, trustHost, callback update

### DIFF
--- a/app/actions/actions.ts
+++ b/app/actions/actions.ts
@@ -11,20 +11,14 @@ export async function doCredentialLogin(formData: FormData) {
     };
   }
 
-  await signIn('credentials', {
-    username,
-    password,
+  const res = await signIn('credentials', {
+    username: formData.get('username'),
+    password: formData.get('password'),
     redirect: false,
-  })
-    .then((res) => {
-      return res;
-    })
-    .catch((err) => {
-      console.error(err);
-      return {
-        error: 'Please provide valid credentials',
-      };
-    });
+  });
+
+  if (!res) return null;
+  return res;
 }
 
 export async function logout() {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -47,7 +47,7 @@ export default function LoginPage() {
             name="username"
             id="username"
             placeholder="username"
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight"
           />
         </div>
 
@@ -62,7 +62,7 @@ export default function LoginPage() {
             type="password"
             id="password"
             name="password"
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight"
           />
         </div>
         <div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,23 +4,28 @@ import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { doCredentialLogin } from '../actions/actions';
 import SplitLayout from '../components/layout/SplitLayout';
-
 export default function LoginPage() {
+  // set up state for the form fields
   const [error, setError] = useState('');
   const router = useRouter();
 
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
 
-    await doCredentialLogin(formData)
-      .then(() => {
+    try {
+      const formData = new FormData(event.currentTarget);
+      const response = await doCredentialLogin(formData);
+
+      if (!!response.error) {
+        console.error(response.error);
+        setError(response.error.message);
+      } else {
         router.push('/dashboard');
-      })
-      .catch((err) => {
-        console.error(err);
-        setError('Please provide valid credentials');
-      });
+      }
+    } catch (e) {
+      console.error(e);
+      setError('Check your Credentials');
+    }
   };
 
   return (
@@ -31,7 +36,10 @@ export default function LoginPage() {
         onSubmit={handleLogin}
       >
         <div>
-          <label className="block text-md font-bold mb-2" htmlFor="username">
+          <label
+            className="block text-text text-md font-bold mb-2"
+            htmlFor="email"
+          >
             Username
           </label>
           <input
@@ -39,37 +47,49 @@ export default function LoginPage() {
             name="username"
             id="username"
             placeholder="username"
-            className="shadow border rounded w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline"
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
           />
         </div>
 
         <div>
-          <label className="block text-md font-bold mb-2" htmlFor="password">
+          <label
+            className="block text-text text-md font-bold mb-2"
+            htmlFor="password"
+          >
             Password
           </label>
           <input
             type="password"
             id="password"
             name="password"
-            className="shadow border rounded w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline"
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
           />
         </div>
+        <div>
+          <p className="text-sm text-text">
+            Don&apos;t have an account?
+            <a href="/register" className="text-blue-500">
+              {' '}
+              Register Now
+            </a>
+          </p>
+        </div>
 
-        <p className="text-sm">
-          Don&apos;t have an account?{' '}
-          <a href="/register" className="text-blue-500">
-            Register Now
-          </a>
-        </p>
-
-        <button
-          type="submit"
-          className="bg-primary hover:bg-secondary text-white font-bold py-2 px-10 rounded focus:outline-none focus:shadow-outline"
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+          }}
         >
-          Login
-        </button>
+          <button
+            type="submit"
+            className="bg-primary hover:bg-secondary text-white font-bold py-2 px-10 rounded focus:outline-none focus:shadow-outline w-auto"
+          >
+            Login
+          </button>
+        </div>
       </form>
-      {error && <p className="text-red-500 mt-4">{error}</p>}
+      <div>{error && <p>{error}</p>}</div>
     </SplitLayout>
   );
 }

--- a/auth.js
+++ b/auth.js
@@ -33,8 +33,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
           return {
             id: user.id,
-            name: user.username ?? user.firstName,
-            email: user.email,
+            name: user.username,
+            email: user.email || null,
           };
         } catch (error) {
           throw new Error(error);
@@ -46,4 +46,5 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     signIn: '/login',
     signOut: '/login',
   },
+  trustHost: true,
 });

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,8 +6,8 @@ frontend:
         - npm ci
     build:
       commands:
-        - env | grep -e DATABUSE_URL -e NEXTAUTH_URL -e NEXTAUTH_SECRET >> .env.production
-        - env | grep -e NEXT_PUBLIC_ >> .env.production
+        - env | grep -e DATABUSE_URL >> .env.production
+        - env | grep -e NEXTAUTH >> .env.production
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ frontend:
     build:
       commands:
         - env | grep -e DATABUSE_URL >> .env.production
-        - env | grep -e NEXTAUTH >> .env.production
+        - env | grep -e NEXTAUTH_ >> .env.production
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,14 +3,17 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm install
+        - npm ci
     build:
       commands:
-        - npm ci
+        - env | grep -e DATABUSE_URL -e NEXTAUTH_URL -e NEXTAUTH_SECRET >> .env.production
+        - env | grep -e NEXT_PUBLIC_ >> .env.production
         - npm run build
   artifacts:
-    baseDirectory: .next # Specify where the build output is located
+    baseDirectory: .next
     files:
       - '**/*'
   cache:
     paths:
+      - node_modules/**/*
+      - .next/cache/**/*

--- a/next.config.js
+++ b/next.config.js
@@ -2,5 +2,6 @@ module.exports = {
   env: {
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     DATABASE_URL: process.env.DATABASE_URL,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL,
   },
 };


### PR DESCRIPTION
This has been a really annoying problem to debug - 

In the CloudWatch logs of the Amplify deployment following the addition of next-auth v5, a mysql db hosted in RDS, and next 15 I see this when trying to login:

```
2025-01-19T06:56:34.939Z
Starting request using compute deployment_id: 0000000052 and compute version: $LATEST
2025-01-19T06:56:34.945Z
[31m[auth][error][0m UntrustedHost: Host must be trusted. URL was: https://main.dwb6ufme8pe93.amplifyapp.com/api/auth/session. Read more at https://errors.authjs.dev#untrustedhost
2025-01-19T06:56:34.945Z
at /var/task/.next/server/chunks/173.js:368:53174
2025-01-19T06:56:34.945Z
at iO (/var/task/.next/server/chunks/173.js:368:55845)
2025-01-19T06:56:34.945Z
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-01-19T06:56:34.974Z
REPORT RequestId: 966a8ab3-57a9-4814-84f3-6b72c512d9fa Duration: 36.39 ms Billed Duration: 37 ms Memory Size: 1024 MB Max Memory Used: 148 MB
2025-01-19T06:56:51.881Z
START RequestId: cd97e3e5-83aa-476b-9733-289b7768b992 Version: $LATEST
2025-01-19T06:56:51.882Z
Starting request using compute deployment_id: 0000000052 and compute version: $LATEST
2025-01-19T06:56:52.716Z
prisma:error
2025-01-19T06:56:52.716Z
Invalid `prisma.user.create()` invocation:
2025-01-19T06:56:52.716Z
Prisma Client could not locate the Query Engine for runtime "rhel-openssl-1.0.x".
2025-01-19T06:56:52.716Z
This happened because Prisma Client was generated for "rhel-openssl-3.0.x", but the actual deployment required "rhel-openssl-1.0.x".
2025-01-19T06:56:52.716Z
Add "rhel-openssl-1.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:
2025-01-19T06:56:52.716Z
generator client {
2025-01-19T06:56:52.716Z
provider = "prisma-client-js"
2025-01-19T06:56:52.716Z
binaryTargets = ["native", "rhel-openssl-1.0.x"]
2025-01-19T06:56:52.716Z
}
2025-01-19T06:56:52.716Z
The following locations have been searched:
2025-01-19T06:56:52.716Z
/var/task/node_modules/.prisma/client
2025-01-19T06:56:52.716Z
/var/task/node_modules/@prisma/client
2025-01-19T06:56:52.716Z
/codebuild/output/src679080930/src/aws-learner/node_modules/@prisma/client
2025-01-19T06:56:52.716Z
/tmp/prisma-engines
```

Clearly some envs are not available to our next components - specifically `DATABASE_URL` and the associated envs needed by next-auth. I've tried many different things, but I did them the lazy way and just pushed to `main` to see if they fixed anything. (They didn't)

I understand Cognito is the AWS preferred way of signing in, but I don't want to do that for the time being. The point of this exercise was to have a simple and vanilla implementation of a credentials provider, even if just for future reference. This all works great locally (`trustHost` did have to be added to the auth configuration). 

This [guide to making envs available from AWS](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-environment-variables.html) was used for this PR. In an earlier commit I used `echo` and didn't add the envs to `env.production` as I see being done in the linked example - perhaps that was the issue 🤷 

`trustHost` does need to be present in the next auth config for the very same "untrusted host" warning not to occur when building and running locally. 

## Testing 

1. `docker compose up` && `npm run build` && `npm run start` 
2. Visit the page, register if needed
3. Login 
4. Look at console - no untrusted host warning should be visible 