### PR TITLE
feat: adds task toolbar

### DIFF
--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -16,9 +16,8 @@ import {
 } from '@dnd-kit/sortable';
 import { useTaskStore } from '@/lib/store/task';
 import { useNoteStore } from '@/lib/store/note';
-import { useTagStore } from '@/lib/store/tag';
 import SortableTaskItem from './SortableTaskItem';
-import TagItem from './TagItem';
+import TasksToolbar from '../TasksToolbar.tsx';
 
 /**
  * A component that renders a draggable and sortable list of tasks.
@@ -35,9 +34,8 @@ import TagItem from './TagItem';
  * @returns {React.ReactElement} A JSX element representing the task list.
  */
 const ClientTaskList = (): React.ReactElement => {
-  const { tasks, reorderTask, setCurrentTagId, currentTagId } = useTaskStore();
+  const { tasks, reorderTask } = useTaskStore();
   const { isLinking } = useNoteStore();
-  const { tags } = useTagStore();
 
   //TODO: better classes - clsx?
   const listPadding = isLinking ? 'py-2 px-4' : '';
@@ -58,15 +56,6 @@ const ClientTaskList = (): React.ReactElement => {
     })
   );
 
-  const handleTagChange = (tagId: string) => {
-    // if the tagId is the same as the currentTagId, reset the currentTagId
-    if (tagId === currentTagId) {
-      setCurrentTagId(null);
-      return;
-    }
-    setCurrentTagId(tagId);
-  };
-
   // dnd setup
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -79,43 +68,28 @@ const ClientTaskList = (): React.ReactElement => {
   };
 
   return (
-    <div>
-      <div className="flex justify-between items-center">
-        <h2 className="text-text text-2xl font-bold">Tasks</h2>
-        {/** TODO: Create function to show completed tasks (update list ordering/visibility) */}
-        {/* <button className="border p-3 py-2 rounded bg-gray-200">
-          View Completed
-        </button> */}
-      </div>
-      <div>
-        <div className="flex gap-2 py-4">
-          {tags.map((tag) => (
-            <TagItem
-              key={tag.id}
-              tag={tag}
-              currentTagId={currentTagId}
-              handleTagChange={handleTagChange}
-            />
-          ))}
-        </div>
-      </div>
-      <DndContext
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-        sensors={sensors}
-      >
-        <SortableContext
-          items={tasks.map((task) => task.id)}
-          strategy={verticalListSortingStrategy}
+    <>
+      <h2 className="text-text text-2xl font-bold mb-4">Your Tasks</h2>
+      <div className="flex flex-col gap-4">
+        <TasksToolbar />
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          sensors={sensors}
         >
-          <ul className={`${listPadding} ${listBorder}`}>
-            {tasks.map((task) => (
-              <SortableTaskItem key={task.id} task={task} />
-            ))}
-          </ul>
-        </SortableContext>
-      </DndContext>
-    </div>
+          <SortableContext
+            items={tasks.map((task) => task.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className={`${listPadding} ${listBorder}`}>
+              {tasks.map((task) => (
+                <SortableTaskItem key={task.id} task={task} />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      </div>
+    </>
   );
 };
 

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
 import { useNoteStore } from '@/lib/store/note';
+import { useSelectedTaskStore } from '@/lib/store/selected.task';
 import MeatballMenu from '../../MeatballMenu';
 import { COLORS } from '@/utils/constants';
 import DueDateModal from './DueDateModal';
@@ -18,9 +19,10 @@ import DueDateModal from './DueDateModal';
 const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDueDateModalOpen, setIsDueDateModalOpen] = useState(false);
-  const { deleteTask, toggleComplete } = useTaskStore();
+  const { deleteTask } = useTaskStore();
+  const { selectedTaskIds, setSelectedTaskIds } = useSelectedTaskStore();
 
-  const { setSelectedTaskIds, selectedTaskIds, isLinking } = useNoteStore();
+  const { isLinking } = useNoteStore();
 
   // get the background color for the task from the color col
   const bgColor = task.color
@@ -28,10 +30,9 @@ const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
     : 'bg-note';
 
   // TODO - better classes - clsx?
-  const borderColor =
-    isLinking && selectedTaskIds.includes(task.id)
-      ? 'border-2 border-highlight'
-      : '';
+  const borderColor = selectedTaskIds.includes(task.id)
+    ? 'border-2 border-highlight'
+    : '';
 
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
@@ -55,21 +56,12 @@ const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
     },
   ];
 
-  //TODO: clean up this logic - extract?
-  // switcher between using the checkbox during linking
-  // if isLinking is true, then the input action should add the taskId to the selectedTaskIds array
-  // if isLinking is false, then it should toggleComplete
   const handleCheckboxChange = () => {
-    if (isLinking) {
-      setSelectedTaskIds(task.id);
-    } else {
-      toggleComplete(task.id);
-    }
+    if (isLinking) return setSelectedTaskIds(task.id);
+    setSelectedTaskIds(task.id);
   };
 
-  const checked = isLinking
-    ? selectedTaskIds.includes(task.id)
-    : task.completed;
+  const checked = selectedTaskIds.includes(task.id);
 
   return (
     <div

--- a/app/components/TasksToolbar.tsx/TagItem.tsx
+++ b/app/components/TasksToolbar.tsx/TagItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Tag } from '@/lib/db';
+import { COLORS } from '@/utils/constants';
 
 type TagSortingProps = {
   currentTagId: string | null;
@@ -17,15 +18,18 @@ type TagSortingProps = {
  * @param {TagSortingProps} props - The props for the component.
  */
 const TagItem = ({ tag, currentTagId, handleTagChange }: TagSortingProps) => {
+  const bgColor = tag.color
+    ? COLORS.find((color) => color.name === tag.color)?.class
+    : 'bg-note';
   return (
     <button
       key={tag.id}
       className={`
-                px-2 py-2 text-sm font-bold rounded rounded-full bg-primary hover:bg-secondary text-white ${
-                  currentTagId === tag.id
-                    ? 'border-2 border-highlight bg-secondary'
-                    : 'border-2 border-transparent'
-                }`}
+                px-2 py-2 text-sm font-bold rounded rounded-full ${bgColor} text-secondary ${
+        currentTagId === tag.id
+          ? 'border-2 border-highlight bg-secondary text-white'
+          : 'border-2 border-transparent'
+      }`}
       onClick={() => handleTagChange(tag.id)}
     >
       {tag.name}

--- a/app/components/TasksToolbar.tsx/TasksToolbar.tsx
+++ b/app/components/TasksToolbar.tsx/TasksToolbar.tsx
@@ -22,10 +22,6 @@ const TasksToolbar = () => {
     setCurrentTagId(tagId);
   };
 
-  // make container a grid with two columns
-  // the input grows to fill as much space as it can
-  // the buttons fill the remaining space
-  // is a grid with one columns and 2 rows at small screen sizes
   return (
     <div className="p-2 rounded shadow bg-utility flex flex-col gap-2">
       <div>

--- a/app/components/TasksToolbar.tsx/TasksToolbar.tsx
+++ b/app/components/TasksToolbar.tsx/TasksToolbar.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { useTaskStore } from '@/lib/store/task';
+import { useSelectedTaskStore } from '@/lib/store/selected.task';
+import { useNoteStore } from '@/lib/store/note';
+import { useTagStore } from '@/lib/store/tag';
+import TagItem from './TagItem';
+
+const TasksToolbar = () => {
+  const { selectAllTasks, deleteSelectedTasks, setCurrentTagId, currentTagId } =
+    useTaskStore();
+  const { clearSelectedTaskIds } = useSelectedTaskStore();
+  const { isLinking } = useNoteStore();
+  const { tags } = useTagStore();
+
+  const handleTagChange = (tagId: string) => {
+    clearSelectedTaskIds();
+    // if the tagId is the same as the currentTagId, reset the currentTagId
+    if (tagId === currentTagId) {
+      setCurrentTagId(null);
+      return;
+    }
+    setCurrentTagId(tagId);
+  };
+
+  // make container a grid with two columns
+  // the input grows to fill as much space as it can
+  // the buttons fill the remaining space
+  // is a grid with one columns and 2 rows at small screen sizes
+  return (
+    <div className="p-2 rounded shadow bg-utility flex flex-col gap-2">
+      <div>
+        <p className="text-sm italic text-secondary pb-2">Filter by Tag</p>
+        <div className="flex gap-1">
+          {tags.map((tag) => (
+            <TagItem
+              key={tag.id}
+              tag={tag}
+              currentTagId={currentTagId}
+              handleTagChange={handleTagChange}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <p className="text-sm italic text-secondary pb-2">Actions</p>
+        <div>
+          {/** Rounded search input - standin for now */}
+          {/* <input
+          type="text"
+          placeholder="Search"
+          className="bg-white rounded-full disabled:bg-gray-400 hover:bg-secondary
+        text-white px-2 text-sm
+        h-10
+        "
+        /> */}
+          <div className="flex gap-2">
+            <button
+              className="bg-primary rounded disabled:bg-gray-400 hover:bg-secondary
+        text-white p-2 text-sm
+        "
+              onClick={selectAllTasks}
+            >
+              Select All
+            </button>
+            <button
+              className="bg-primary rounded disabled:bg-gray-400 hover:bg-secondary
+        text-white p-2 text-sm
+        "
+              onClick={deleteSelectedTasks}
+              disabled={isLinking}
+            >
+              Delete Selected
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TasksToolbar;

--- a/app/components/TasksToolbar.tsx/index.ts
+++ b/app/components/TasksToolbar.tsx/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TasksToolbar';

--- a/app/components/TextEditor/Toolbar.tsx
+++ b/app/components/TextEditor/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { Editor } from '@tiptap/react';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 /**
  * A toolbar component for the TextEditor.
@@ -16,11 +16,11 @@ const Toolbar = ({ editor }: { editor: Editor | null }): JSX.Element | null => {
   if (!editor) return null;
 
   return (
-    <div className="flex space-x-2 bg-gray-100 p-2 rounded-t shadow">
+    <div className="flex space-x-2 bg-utility p-2 rounded-t shadow">
       {/* Bold Button */}
       <button
-        className={`px-2 py-1 border rounded ${
-          editor.isActive('bold') ? 'bg-primary text-text' : ''
+        className={`px-2 py-1 bg-primary rounded text-white ${
+          editor.isActive('bold') ? 'bg-secondary' : ''
         }`}
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={!editor.can().chain().focus().toggleBold().run()}
@@ -30,8 +30,8 @@ const Toolbar = ({ editor }: { editor: Editor | null }): JSX.Element | null => {
 
       {/* Italic Button */}
       <button
-        className={`px-2 py-1 border rounded ${
-          editor.isActive('italic') ? 'bg-primary text-text' : ''
+        className={`px-2 py-1 border rounded bg-primary text-white ${
+          editor.isActive('italic') ? 'bg-secondary' : ''
         }`}
         onClick={() => editor.chain().focus().toggleItalic().run()}
         disabled={!editor.can().chain().focus().toggleItalic().run()}
@@ -41,7 +41,7 @@ const Toolbar = ({ editor }: { editor: Editor | null }): JSX.Element | null => {
 
       {/* Undo */}
       <button
-        className="px-2 py-1 border rounded"
+        className="px-2 py-1 border rounded bg-primary text-white"
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().chain().focus().undo().run()}
       >
@@ -50,7 +50,7 @@ const Toolbar = ({ editor }: { editor: Editor | null }): JSX.Element | null => {
 
       {/* Redo */}
       <button
-        className="px-2 py-1 border rounded"
+        className="px-2 py-1 border rounded bg-primary text-white"
         onClick={() => editor.chain().focus().redo().run()}
         disabled={!editor.can().chain().focus().redo().run()}
       >

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,14 +5,15 @@
 @tailwind utilities;
 
 :root {
-  --background: #0d1b2a;
-  --foreground: #1b263b;
-  --color-primary: #3c51cb;
-  --color-secondary: #7b42dd;
-  --color-text: #c5cbe3;
-  --color-note: #ccb6f1;
-  --color-highlight: #9c27b0;
-  --color-modal: #3c51cb;
+  --background: #f4f7f5;
+  --foreground: #f4f7f5;
+  --color-primary: #21a0a0;
+  --color-secondary: #046865;
+  --color-text: #074846;
+  --color-note: #e9f7ee;
+  --color-highlight: #41d070;
+  --color-modal: #e9f7ee;
+  --color-utility: #d1f0dc;
 }
 
 .Tidepool {
@@ -24,6 +25,7 @@
   --color-note: #e9f7ee;
   --color-highlight: #41d070;
   --color-modal: #e9f7ee;
+  --color-utility: #d1f0dc;
 }
 
 .Orchid {
@@ -35,6 +37,7 @@
   --color-note: #ecd5ec;
   --color-highlight: #e766cd;
   --color-modal: #61195c;
+  --color-utility: #f5ccf2;
 }
 
 .Jewel {
@@ -46,6 +49,7 @@
   --color-note: #e0f7fa;
   --color-highlight: #ff376c;
   --color-modal: #f8f4ff;
+  --color-utility: #ede5fa;
 }
 
 .DeepSpace {
@@ -57,6 +61,7 @@
   --color-note: #ccb6f1;
   --color-highlight: #9c27b0;
   --color-modal: #3c51cb;
+  --color-utility: #c3ccef;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -90,4 +90,7 @@ export class TaskService {
   updateTaskPosition = async (id: string, newPosition: number) => {
     await db.tasks.update(id, { position: newPosition });
   };
+  deleteByIds = async (taskIds: string[]) => {
+    await db.tasks.bulkDelete(taskIds);
+  };
 }

--- a/lib/store/selected.task.ts
+++ b/lib/store/selected.task.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+interface SelectedTaskStore {
+  selectedTaskIds: string[];
+  setSelectedTaskIds: (taskId: string) => void;
+  clearSelectedTaskIds: () => void;
+}
+
+/**
+ * @type {SelectedTaskStore}
+ * @name SelectedTaskStore
+ * @description A zustand store for managing user-selected task IDs.
+ * @returns {SelectedTaskStore}
+ */
+export const useSelectedTaskStore = create<SelectedTaskStore>((set) => ({
+  selectedTaskIds: [],
+  /**
+   * Toggle a task ID in the `selectedTaskIds` array.
+   *
+   * If the task ID is already present in the array, it will be removed.
+   * If the task ID is not present in the array, it will be added.
+   *
+   * @param {string} taskId The task ID to toggle.
+   * @returns {void}
+   */
+  setSelectedTaskIds: (taskId: string) => {
+    set((state) => ({
+      selectedTaskIds: state.selectedTaskIds.includes(taskId)
+        ? state.selectedTaskIds.filter((id) => id !== taskId)
+        : [...state.selectedTaskIds, taskId],
+    }));
+  },
+  /**
+   * Resets the `selectedTaskIds` array to an empty array.
+   *
+   * @returns {void}
+   */
+  clearSelectedTaskIds: () => {
+    set({ selectedTaskIds: [] });
+  },
+}));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,7 @@ export default {
         // custom set up
         primary: 'var(--color-primary)',
         secondary: 'var(--color-secondary)',
+        utility: 'var(--color-utility)',
         highlight: 'var(--color-highlight)',
         text: 'var(--color-text)',
         note: 'var(--color-note)', // for the default note bg color

--- a/tests/TaskToolbar.test.tsx
+++ b/tests/TaskToolbar.test.tsx
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import TasksToolbar from '@/app/components/TasksToolbar.tsx';
+//import userEvent from '@testing-library/user-event';
+
+// Mock Zustand stores
+jest.mock('@/lib/store/tag', () => ({
+  useTagStore: jest.fn(() => ({
+    tags: [
+      { id: '1', name: 'Tag 1' },
+      { id: '2', name: 'Tag 2' },
+      { id: '3', name: 'Tag 3' },
+    ],
+  })),
+}));
+
+jest.mock('@/lib/store/task', () => ({
+  useTaskStore: jest.fn(() => ({
+    tasks: [
+      {
+        id: '1',
+        text: 'Task 1',
+        completed: false,
+        dateAdded: new Date(),
+        dateUpdated: new Date(),
+        position: 1,
+        userId: '1',
+        dueDate: new Date(),
+      },
+      {
+        id: '2',
+        text: 'Task 2',
+        completed: false,
+        dateAdded: new Date(),
+        dateUpdated: new Date(),
+        position: 2,
+        userId: '1',
+        dueDate: new Date(),
+      },
+      {
+        id: '3',
+        text: 'Task 3',
+        completed: false,
+        dateAdded: new Date(),
+        dateUpdated: new Date(),
+        position: 3,
+        userId: '1',
+        dueDate: new Date(),
+      },
+    ],
+    selectAllTasks: jest.fn(),
+    deleteSelectedTasks: jest.fn(),
+    setCurrentTagId: jest.fn(),
+    currentTagId: null,
+  })),
+}));
+
+jest.mock('@/lib/store/selected.task', () => ({
+  useSelectedTaskStore: jest.fn(() => ({
+    clearSelectedTaskIds: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/store/note', () => ({
+  useNoteStore: jest.fn(() => ({
+    isLinking: false,
+  })),
+}));
+
+expect.extend(toHaveNoViolations);
+
+describe('AddTasks Automated Accessibility Tests', () => {
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<TasksToolbar />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Changes 
- unifies selected tasks logic 
- updates task and note stores
- adds TaskToolbar
- select all/delete all functionality

<img width="458" alt="image" src="https://github.com/user-attachments/assets/cb94d341-edc2-4074-82dd-589b4f9f1d34" />

Not the most beautiful design right now - but I was more focused on getting the key functionality to behave as expected, and unifying our approach to `selectedTaskIds` 

There were being set in both the Task and Note store, managed independently of each other. But I thought it best to create a singular store for the tasks a user has selected, that way it could be used between both and used to make requests to manage tasks, and their relationship to notes. 