### PR TITLE
feat: add lighthouse score table and get/store lighthouse results

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,49 @@
+name: Lighthouse Tests
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Next.js app
+        run: npm run build
+
+      - name: Start Next.js server
+        run: npm start &
+        env:
+          PORT: 3000
+
+      - name: Wait for server to start
+        run: curl -s http://localhost:3000/login || exit 1
+        timeout-minutes: 1
+
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli
+
+      - name: Run Lighthouse CI
+        run: lhci autorun --collect.settings.output='json'
+
+      - name: Install Prisma CLI
+        run: npm install @prisma/client
+
+      - name: Save Lighthouse scores to database
+        env:
+          DATABASE_URL: ${{ secrets.MY_APP_DATABASE_URL }}
+        run: node scripts/save-lighthouse-scores.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+/.lighthouseci
 
 # next.js
 /.next/

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,14 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000/dashboard", "http://localhost:3000/login"],
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "preset": "lighthouse:recommended"
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/prisma/migrations/20250201182957_add_lighthouse_scores/migration.sql
+++ b/prisma/migrations/20250201182957_add_lighthouse_scores/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE `LighthouseScore` (
+    `id` VARCHAR(191) NOT NULL,
+    `url` VARCHAR(191) NOT NULL,
+    `performance` DOUBLE NOT NULL,
+    `accessibility` DOUBLE NOT NULL,
+    `bestPractices` DOUBLE NOT NULL,
+    `seo` DOUBLE NOT NULL,
+    `timestamp` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-1.0.x"]
 }
 
@@ -39,4 +39,15 @@ model Task {
   position    Int
   userId      String
   dueDate     DateTime
+}
+
+// Lighthouse CI scores 
+model LighthouseScore {
+  id            String   @id @default(uuid())
+  url           String
+  performance   Float
+  accessibility Float
+  bestPractices Float
+  seo           Float
+  timestamp     DateTime @default(now())
 }

--- a/scripts/save-lighthouse-scores.js
+++ b/scripts/save-lighthouse-scores.js
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs');
+const path = require('path');
+const { PrismaClient } = require('@prisma/client');
+
+// Define __dirname for CommonJS (Node.js automatically provides it)
+const prisma = new PrismaClient();
+
+async function getReports() {
+  const reportsDir = path.join(__dirname, '../.lighthouseci');
+
+  // Get all JSON reports
+  const reportFiles = fs
+    .readdirSync(reportsDir)
+    .filter((file) => file.endsWith('.json') && file.startsWith('lhr'))
+    .map((file) => path.join(reportsDir, file));
+
+  // Read and parse reports
+  return reportFiles.map((file) => JSON.parse(fs.readFileSync(file, 'utf8')));
+}
+
+function aggregateReports(reports) {
+  const groupedReports = {};
+
+  reports.forEach((report) => {
+    const url = report.finalUrl;
+
+    if (!groupedReports[url]) {
+      groupedReports[url] = {
+        performance: 0,
+        accessibility: 0,
+        bestPractices: 0,
+        seo: 0,
+        count: 0,
+      };
+    }
+
+    groupedReports[url].performance +=
+      report.categories.performance.score * 100;
+    groupedReports[url].accessibility +=
+      report.categories.accessibility.score * 100;
+    groupedReports[url].bestPractices +=
+      report.categories['best-practices'].score * 100;
+    groupedReports[url].seo += report.categories.seo.score * 100;
+    groupedReports[url].count += 1;
+  });
+
+  for (const url in groupedReports) {
+    const data = groupedReports[url];
+    groupedReports[url] = {
+      performance: data.performance / data.count,
+      accessibility: data.accessibility / data.count,
+      bestPractices: data.bestPractices / data.count,
+      seo: data.seo / data.count,
+    };
+  }
+
+  return groupedReports;
+}
+
+async function saveScoresToDatabase(aggregatedData) {
+  for (const [url, scores] of Object.entries(aggregatedData)) {
+    await prisma.lighthouseScore.create({
+      data: {
+        url,
+        performance: scores.performance,
+        accessibility: scores.accessibility,
+        bestPractices: scores.bestPractices,
+        seo: scores.seo,
+      },
+    });
+  }
+
+  console.log('Lighthouse scores saved successfully.');
+}
+
+async function main() {
+  const reports = await getReports();
+  const aggregatedData = aggregateReports(reports);
+  await saveScoresToDatabase(aggregatedData);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Changes 

- Adds [@lhci/cli](https://www.npmjs.com/package/@lhci/cli)
- Adds `lighthouse.yml` github action 
- Adds `LighthouseScore` table to database 
- Adds `save-lighthouse-score` script, used in `lighthouse.yml` to record our lighthouse scores to the database 

