### PR TITLE
feat: migrate tasks from indexDb to Prisma 

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,144 @@
+import { prisma } from '@/lib/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Handles a GET request to fetch tasks for a given user.
+ *
+ * Retrieves tasks associated with a specific user, optionally filtered by a tag.
+ * If a `tagId` is provided in the query parameters, it fetches tasks linked
+ * to that tag for the specified `userId`. If no `tagId` is provided, it fetches
+ * all tasks for the specified `userId`.
+ *
+ * @param {NextRequest} req - The incoming request object containing URL parameters.
+ *
+ * @returns {NextResponse} - A JSON response containing the fetched tasks or an error message.
+ *
+ * @throws Will log an error and respond with a 500 status if task retrieval fails.
+ * Responds with a 400 status if `userId` is not provided in the query parameters.
+ */
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  const tagId = searchParams.get('tagId');
+
+  if (!userId)
+    return NextResponse.json({ error: 'UserId is required' }, { status: 400 });
+
+  try {
+    let tasks;
+    if (tagId) {
+      // Fetch tasks by tag
+      tasks = await prisma.task.findMany({
+        where: {
+          userId,
+          taskTags: {
+            some: {
+              tagId: tagId,
+            },
+          },
+        },
+        include: {
+          tags: true,
+        },
+        orderBy: { position: 'asc' },
+      });
+    } else {
+      // Fetch all tasks by user
+      tasks = await prisma.task.findMany({
+        where: { userId },
+        include: {
+          tags: true,
+        },
+      });
+    }
+    return NextResponse.json(tasks);
+  } catch (error) {
+    console.error('Failed to fetch tasks:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch tasks' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  //TODO: add other items in here - dueDate, tag, etc
+  const { text, userId } = body;
+
+  if (!text)
+    return NextResponse.json({ error: 'Text is required' }, { status: 400 });
+
+  try {
+    // TODO: fetch tasks by position and get the last one
+    // then determine the new task's position on that
+    const newTask = await prisma.task.create({
+      data: {
+        text,
+        userId,
+        // position
+      },
+    });
+    return NextResponse.json(newTask, { status: 201 });
+  } catch (error) {
+    console.error('Failed to add task:', error);
+    return NextResponse.json({ error: 'Failed to add task' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const body = await req.json();
+  const { id } = body; // Can be an array of IDs or a single ID
+
+  if (!id)
+    return NextResponse.json({ error: 'Id is required' }, { status: 400 });
+
+  try {
+    if (Array.isArray(id)) {
+      await prisma.task.deleteMany({
+        where: { id: { in: id } },
+      });
+    } else {
+      await prisma.task.delete({ where: { id } });
+    }
+
+    return NextResponse.json(
+      { message: 'Task deleted successfully' },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Failed to delete task:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete task' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const body = await req.json();
+  const { id, ...updates } = body;
+
+  if (!id) {
+    return NextResponse.json(
+      { error: 'Task ID is required.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const updatedTask = await prisma.task.update({
+      where: { id },
+      data: { ...updates, dateUpdated: new Date() },
+    });
+
+    return NextResponse.json(updatedTask);
+  } catch (error) {
+    console.error('Failed to update task:', error);
+    return NextResponse.json(
+      { error: 'Failed to update task' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -117,37 +117,60 @@ export async function DELETE(req: NextRequest) {
 }
 
 // TODO: this might go better in a separate route - task/route?
+// export async function PATCH(req: NextRequest) {
+//   const body = await req.json();
+//   const { id } = body;
+
+//   if (!id) {
+//     return NextResponse.json(
+//       { error: 'Task ID is required.' },
+//       { status: 400 }
+//     );
+//   }
+
+//   try {
+//     const existingTask = await prisma.task.findUnique({ where: { id } });
+//     if (!existingTask) {
+//       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+//     }
+
+//     // Toggle completion status
+//     const updatedTask = await prisma.task.update({
+//       where: { id },
+//       data: {
+//         completed: !existingTask.completed,
+//         dateUpdated: new Date(),
+//       },
+//     });
+
+//     return NextResponse.json(updatedTask);
+//   } catch (error) {
+//     console.error('❌ Failed to toggle task completion:', error);
+//     return NextResponse.json(
+//       { error: 'Failed to toggle task completion' },
+//       { status: 500 }
+//     );
+//   }
+// }
+
 export async function PATCH(req: NextRequest) {
   const body = await req.json();
-  const { id } = body;
+  const { id, ...updates } = body;
 
-  if (!id) {
-    return NextResponse.json(
-      { error: 'Task ID is required.' },
-      { status: 400 }
-    );
-  }
+  if (!id)
+    return NextResponse.json({ error: 'Id is required' }, { status: 400 });
 
   try {
-    const existingTask = await prisma.task.findUnique({ where: { id } });
-    if (!existingTask) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
-    }
-
-    // Toggle completion status
     const updatedTask = await prisma.task.update({
       where: { id },
-      data: {
-        completed: !existingTask.completed,
-        dateUpdated: new Date(),
-      },
+      data: { ...updates },
     });
 
     return NextResponse.json(updatedTask);
   } catch (error) {
-    console.error('❌ Failed to toggle task completion:', error);
+    console.error('❌ Failed to update task:', error);
     return NextResponse.json(
-      { error: 'Failed to toggle task completion' },
+      { error: 'Failed to update task' },
       { status: 500 }
     );
   }

--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -15,13 +15,12 @@ import TagSelector from './TagSelector';
 const AddTasks = () => {
   const { addTask } = useTaskStore();
   const [taskText, setTaskText] = useState('');
-  const [taskColor, setTaskColor] = useState('green');
   const [taskTag, setTaskTag] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleAddTask = async () => {
     if (!taskText.trim()) return;
-    await addTask(taskText, taskColor, taskTag);
+    await addTask(taskText);
     setTaskText('');
     inputRef.current?.focus();
   };
@@ -30,11 +29,8 @@ const AddTasks = () => {
     e.preventDefault();
     handleAddTask();
   };
-
-  // TODO: why doesn't this reset task color?
   const handleClearTaskInput = () => {
     setTaskText('');
-    setTaskColor('green');
     setTaskTag('');
     inputRef.current?.focus();
   };
@@ -59,13 +55,6 @@ const AddTasks = () => {
             className="flex-grow rounded bg-transparent focus:outline focus:outline-highlight text-text-secondary"
             placeholder="Describe your task..."
           />
-
-          {/* 
-          TODO: I want to move away from assigning colors to tasks this way
-          Instead we'll give tags a color and color the task based on the tag
-          <ColorSelector
-            onColorSelect={(color: string) => setTaskColor(color)}
-          /> */}
           <TagSelector
             selectedTag={taskTag}
             onTagSelect={(tag: string) => setTaskTag(tag)}

--- a/auth.js
+++ b/auth.js
@@ -48,4 +48,19 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     signOut: '/login',
   },
   trustHost: true,
+  callbacks: {
+    async jwt({ user, token }) {
+      if (user) {
+        token.id = user.id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token.id) {
+        // add id to the session object
+        session.user.id = token.id;
+      }
+      return session;
+    },
+  },
 });

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -13,7 +13,6 @@ export class TaskService {
     try {
       const response = await fetch(`/api/tasks?userId=${userId}`);
       if (!response.ok) throw new Error('Failed to fetch tasks');
-      console.log('Look at that, a response from the API: ', response);
       return await response.json();
     } catch (error) {
       console.error('Failed to fetch tasks:', error);
@@ -26,7 +25,6 @@ export class TaskService {
         `/api/tasks?userId=${userId}&tagId=${tagId}`
       );
       if (!response.ok) throw new Error('Failed to fetch tasks');
-      console.log('Look at that, a response from the API: ', response);
       return await response.json();
     } catch (error) {
       console.error('Failed to fetch tasks:', error);
@@ -45,7 +43,6 @@ export class TaskService {
 
       if (!response.ok) throw new Error('Failed to add task');
       const newTask = await response.json();
-      console.log('Lookie here, a new task: ', newTask);
       return newTask;
     } catch (error) {
       console.error('Failed to add task:', error);
@@ -61,10 +58,8 @@ export class TaskService {
         },
         body: JSON.stringify({ id: id }),
       });
-      console.log('RESPONSE: ', response);
       if (!response.ok) throw new Error('Failed to delete tasks');
       const deletedTasks = await response.json();
-      console.log('Lookie here, a deleted task: ', deletedTasks);
       return deletedTasks;
     } catch (error) {
       console.error('Failed to delete tasks:', error);
@@ -80,10 +75,8 @@ export class TaskService {
         },
         body: JSON.stringify({ id: taskIds }),
       });
-      console.log('RESPONSE: ', response);
       if (!response.ok) throw new Error('Failed to delete tasks');
       const deletedTasks = await response.json();
-      console.log('Lookie here, a deleted task: ', deletedTasks);
       return deletedTasks;
     } catch (error) {
       console.error('Failed to delete tasks:', error);
@@ -116,29 +109,7 @@ export class TaskService {
       await db.tasks.update(id, updatedTask);
     }
   };
-  /**
-   * Update the color of a task background in the UI
-   * @param {string} id - The id of the task to update
-   * @param {string} color - The color to update the task with
-   */
-  updateTaskColor = async (id: string, color: string) => {
-    const task = await db.tasks.get(id);
 
-    if (task) {
-      const updatedTask = { ...task, color, dateUpdated: new Date() };
-      await db.tasks.update(id, updatedTask);
-      return updatedTask;
-    }
-
-    console.warn(`Task with id ${id} not found - color not updated 😢`);
-  };
-  // TODO: remove
-  updateTaskDate = async (id: string) => {
-    const task = await db.tasks.get(id);
-    if (!task) return console.warn(`No task with ${id} to update :(`);
-
-    await db.tasks.update(id, { dateUpdated: new Date() });
-  };
   updateTaskDueDate = async (id: string, dueDate: Date) => {
     const task = await db.tasks.get(id);
     if (!task) return console.warn(`No task with ${id} to update :(`);

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -83,7 +83,24 @@ export class TaskService {
       return null;
     }
   }
+  async toggleComplete(id: string) {
+    try {
+      const response = await fetch('/api/tasks', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id: id }),
+      });
 
+      if (!response.ok) throw new Error('Failed to toggle task completion');
+      const updatedTask = await response.json();
+      return updatedTask;
+    } catch (error) {
+      console.error('Failed to toggle task completion:', error);
+      return null;
+    }
+  }
   // NEED TO BE UPDATED
   // deprecated?
   // async getTasksByIds(taskIds: string[]) {
@@ -96,20 +113,6 @@ export class TaskService {
     await db.tasks.update(task.id, updatedTask);
     return updatedTask;
   };
-
-  toggleComplete = async (id: string) => {
-    const task = await db.tasks.get(id);
-
-    if (task) {
-      const updatedTask = {
-        ...task,
-        completed: !task.completed,
-        dateUpdated: new Date(),
-      };
-      await db.tasks.update(id, updatedTask);
-    }
-  };
-
   updateTaskDueDate = async (id: string, dueDate: Date) => {
     const task = await db.tasks.get(id);
     if (!task) return console.warn(`No task with ${id} to update :(`);

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -1,4 +1,4 @@
-import { db, Task } from '../db';
+import { db } from '../db';
 
 /** This file holds the Task service
  * The Task service is responsible for CRUD operations on the tasks table in the database
@@ -83,14 +83,32 @@ export class TaskService {
       return null;
     }
   }
-  async toggleComplete(id: string) {
+  async toggleComplete(id: string, completed: boolean) {
     try {
       const response = await fetch('/api/tasks', {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ id: id }),
+        body: JSON.stringify({ id: id, completed }),
+      });
+
+      if (!response.ok) throw new Error('Failed to toggle task completion');
+      const updatedTask = await response.json();
+      return updatedTask;
+    } catch (error) {
+      console.error('Failed to toggle task completion:', error);
+      return null;
+    }
+  }
+  async updateTaskDueDate(id: string, dueDate: Date) {
+    try {
+      const response = await fetch('/api/tasks', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id: id, dueDate }),
       });
 
       if (!response.ok) throw new Error('Failed to toggle task completion');
@@ -102,23 +120,6 @@ export class TaskService {
     }
   }
   // NEED TO BE UPDATED
-  // deprecated?
-  // async getTasksByIds(taskIds: string[]) {
-  //   const tasks = await db.tasks.bulkGet(taskIds);
-  //   return tasks;
-  // }
-  updateTask = async (task: Task) => {
-    // get the task, and add a time stamp, and add the task to the database
-    const updatedTask = { ...task, dateUpdated: new Date() };
-    await db.tasks.update(task.id, updatedTask);
-    return updatedTask;
-  };
-  updateTaskDueDate = async (id: string, dueDate: Date) => {
-    const task = await db.tasks.get(id);
-    if (!task) return console.warn(`No task with ${id} to update :(`);
-
-    await db.tasks.update(id, { dueDate: dueDate });
-  };
   updateTaskPosition = async (id: string, newPosition: number) => {
     await db.tasks.update(id, { position: newPosition });
   };

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -1,12 +1,9 @@
-import { db } from '../db';
-
 /** This file holds the Task service
  * The Task service is responsible for CRUD operations on the tasks table in the database
  */
 
 // TODO:
-// Migrate all the service fns to use the API
-// Once moved, update the types with Prisma types - add Promise<type> returns
+// Update the types with Prisma types - add Promise<type> returns
 
 export class TaskService {
   async getAllTasks(userId: string) {
@@ -111,16 +108,30 @@ export class TaskService {
         body: JSON.stringify({ id: id, dueDate }),
       });
 
-      if (!response.ok) throw new Error('Failed to toggle task completion');
+      if (!response.ok) throw new Error('Failed to update task due date');
       const updatedTask = await response.json();
       return updatedTask;
     } catch (error) {
-      console.error('Failed to toggle task completion:', error);
+      console.error('Failed to update task due date:', error);
       return null;
     }
   }
-  // NEED TO BE UPDATED
-  updateTaskPosition = async (id: string, newPosition: number) => {
-    await db.tasks.update(id, { position: newPosition });
-  };
+  async updateTaskPosition(id: string, newPosition: number) {
+    try {
+      const response = await fetch('/api/tasks', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id: id, position: newPosition }),
+      });
+
+      if (!response.ok) throw new Error('Failed to update task order');
+      const updatedTask = await response.json();
+      return updatedTask;
+    } catch (error) {
+      console.error('Failed to update task order:', error);
+      return null;
+    }
+  }
 }

--- a/lib/store/app.ts
+++ b/lib/store/app.ts
@@ -1,7 +1,10 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { DEFAULT_THEME, Theme, THEMES } from '../core/theme.config';
 
 interface AppState {
+  userId: string | null;
+  setUserId: (userId: string) => void;
   view: {
     tasks: boolean;
     notes: boolean;
@@ -11,26 +14,37 @@ interface AppState {
   setTheme: (theme: Theme) => void;
 }
 
-export const useStore = create<AppState>((set) => ({
-  view: {
-    tasks: true,
-    notes: true,
-  },
-  setView: (view, value) => {
-    set((state) => ({
-      view: {
-        ...state.view, // preserve existing view
-        [view]: value, // update the specific view
+export const useStore = create<AppState>()(
+  persist(
+    (set) => ({
+      userId: null, // track the authenticated user's ID
+      setUserId: (userId: string) => {
+        set(() => ({ userId }));
       },
-    }));
-  },
-  theme: DEFAULT_THEME,
-  setTheme: (theme: Theme) => {
-    set(() => ({ theme }));
+      view: {
+        tasks: true,
+        notes: true,
+      },
+      setView: (view, value) => {
+        set((state) => ({
+          view: {
+            ...state.view, // preserve existing view
+            [view]: value, // update the specific view
+          },
+        }));
+      },
+      theme: DEFAULT_THEME,
+      setTheme: (theme: Theme) => {
+        set(() => ({ theme }));
 
-    if (typeof document !== 'undefined') {
-      document.documentElement.classList.remove(...Object.keys(THEMES));
-      document.documentElement.classList.add(theme);
+        if (typeof document !== 'undefined') {
+          document.documentElement.classList.remove(...Object.keys(THEMES));
+          document.documentElement.classList.add(theme);
+        }
+      },
+    }),
+    {
+      name: 'app-storage',
     }
-  },
-}));
+  )
+);

--- a/prisma/migrations/20250215215051_db_init_sync/migration.sql
+++ b/prisma/migrations/20250215215051_db_init_sync/migration.sql
@@ -20,13 +20,13 @@ CREATE TABLE `Task` (
     `id` VARCHAR(191) NOT NULL,
     `text` VARCHAR(191) NOT NULL,
     `completed` BOOLEAN NOT NULL DEFAULT false,
-    `completedBy` VARCHAR(191) NOT NULL,
+    `completedBy` VARCHAR(191) NULL,
     `color` VARCHAR(191) NULL,
     `dateAdded` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `dateUpdated` DATETIME(3) NOT NULL,
     `position` DOUBLE NULL,
     `userId` VARCHAR(191) NULL,
-    `dueDate` DATETIME(3) NOT NULL,
+    `dueDate` DATETIME(3) NULL,
 
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,13 +26,13 @@ model Task {
   id          String    @id @default(uuid())
   text        String
   completed   Boolean   @default(false)
-  completedBy String
+  completedBy String?
   color       String?
   dateAdded   DateTime  @default(now())
   dateUpdated DateTime  @updatedAt
   position    Float?
   userId      String?
-  dueDate     DateTime
+  dueDate     DateTime?
   user        User?     @relation(fields: [userId], references: [id])
   tags        Tag[]     @relation("TaskTags")
   taskTags    TaskTag[]


### PR DESCRIPTION
## Changes 

- Migrates Tasks from using `dexie` and indexDb to keep track of tasks - these are now recorded in the database and fetched by userId 
- Adds /api/tasks/route.ts to centralize where prisma is interacted with - we then interact with the API through the `TaskService` (handles interacting with the API and preparing data) and the `TaskStore` (keep track of an in-memory set of tasks for snappy UI)
- Adds `callbacks` to auth flow, passing the userID to the session and token 