### PR TITLE
fix: task filtering 

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -102,7 +102,19 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    return NextResponse.json(newTask, { status: 201 });
+    // get the task and include the tags
+    const taskWithTags = await prisma.task.findUnique({
+      where: { id: newTask.id },
+      include: {
+        taskTags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(taskWithTags, { status: 201 });
   } catch (error) {
     console.error('Failed to add task:', error);
     return NextResponse.json({ error: 'Failed to add task' }, { status: 500 });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
+import type { TaskWithTags } from '@/lib/store/task';
 
 /**
  * Handles a GET request to fetch tasks for a given user.
@@ -16,10 +17,9 @@ import { NextRequest, NextResponse } from 'next/server';
  * @throws Will log an error and respond with a 500 status if task retrieval fails.
  * Responds with a 400 status if `userId` is not provided in the query parameters.
  */
-export async function GET(req: NextRequest) {
+export async function GET(req: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(req.url);
   const userId = searchParams.get('userId');
-  const tagId = searchParams.get('tagId');
 
   // TODO: Since we're deploying in Amplify, build a small logger for nicely formatted logs
   // And set up a custom error handler and configure Amplify to use it
@@ -38,29 +38,18 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    let tasks;
-    if (tagId) {
-      console.log('🔍 Fetching tasks by tagId:', tagId);
-      tasks = await prisma.task.findMany({
-        where: {
-          userId,
-          taskTags: {
-            some: {
-              tagId: tagId,
-            },
+    console.log('🔍 Fetching all tasks for userId:', userId);
+    const tasks: TaskWithTags[] = await prisma.task.findMany({
+      where: { userId },
+      include: {
+        taskTags: {
+          include: {
+            tag: true,
           },
         },
-        include: { tags: true },
-        orderBy: { position: 'asc' },
-      });
-    } else {
-      console.log('🔍 Fetching all tasks for userId:', userId);
-      tasks = await prisma.task.findMany({
-        where: { userId },
-        include: { tags: true },
-        orderBy: { position: 'asc' },
-      });
-    }
+      },
+      orderBy: { position: 'asc' },
+    });
 
     console.log('✅ Retrieved tasks:', tasks.length, 'tasks found');
     console.log('📋 Tasks Data:', JSON.stringify(tasks, null, 2));

--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -16,13 +16,16 @@ const AddTasks = () => {
   const { addTask } = useTaskStore();
   const [taskText, setTaskText] = useState('');
   const [taskTag, setTaskTag] = useState<string>('');
+  const [loading, setLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleAddTask = async () => {
+    setLoading(true);
     if (!taskText.trim()) return;
     const taskTags = taskTag === '' ? [] : [taskTag];
     await addTask(taskText, taskTags);
     setTaskText('');
+    setLoading(false);
     inputRef.current?.focus();
   };
 
@@ -64,8 +67,9 @@ const AddTasks = () => {
         <div className="flex gap-2">
           <button
             className="w-full text-center font-bold py-2 px-4 rounded-md
-        bg-primary hover:bg-secondary text-white"
+        bg-primary hover:bg-secondary text-white disabled:bg-gray-400"
             type="submit"
+            disabled={taskText === '' || loading}
           >
             Add Task
           </button>

--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -17,6 +17,7 @@ import {
 import { useTaskStore } from '@/lib/store/task';
 import { useNoteStore } from '@/lib/store/note';
 import { useStore } from '@/lib/store/app';
+import LoadingSpinner from '../LoadingSpinner';
 import SortableTaskItem from './SortableTaskItem';
 import TasksToolbar from '../TasksToolbar.tsx';
 import { getSession } from 'next-auth/react';
@@ -36,10 +37,9 @@ import { getSession } from 'next-auth/react';
  * @returns {React.ReactElement} A JSX element representing the task list.
  */
 const ClientTaskList = (): React.ReactElement => {
-  const { tasks, reorderTask, currentTagId } = useTaskStore();
+  const { tasks, reorderTask, currentTagId, loadingTasks } = useTaskStore();
   const { userId, setUserId } = useStore();
   const { isLinking } = useNoteStore();
-  const [loading, setLoading] = React.useState(true);
 
   // Filter tasks in memory based on the current tag
   const filteredTasks = React.useMemo(() => {
@@ -64,7 +64,6 @@ const ClientTaskList = (): React.ReactElement => {
       if (session?.user?.id && session.user.id !== userId) {
         setUserId(session.user.id);
       }
-      setLoading(false);
     };
 
     loadSession();
@@ -96,8 +95,6 @@ const ClientTaskList = (): React.ReactElement => {
     }
   };
 
-  if (loading) return <p>Loading tasks...</p>;
-
   return (
     <>
       <h2 className="text-text text-2xl font-bold mb-4">Your Tasks</h2>
@@ -108,16 +105,19 @@ const ClientTaskList = (): React.ReactElement => {
           onDragEnd={handleDragEnd}
           sensors={sensors}
         >
-          <SortableContext
-            items={tasks.map((task) => task.id)}
-            strategy={verticalListSortingStrategy}
-          >
-            <ul className={`${listPadding} ${listBorder}`}>
-              {filteredTasks.map((task) => (
-                <SortableTaskItem key={task.id} task={task} />
-              ))}
-            </ul>
-          </SortableContext>
+          {loadingTasks && <LoadingSpinner />}
+          {!loadingTasks && (
+            <SortableContext
+              items={tasks.map((task) => task.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul className={`${listPadding} ${listBorder}`}>
+                {filteredTasks.map((task) => (
+                  <SortableTaskItem key={task.id} task={task} />
+                ))}
+              </ul>
+            </SortableContext>
+          )}
         </DndContext>
       </div>
     </>

--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -36,10 +36,20 @@ import { getSession } from 'next-auth/react';
  * @returns {React.ReactElement} A JSX element representing the task list.
  */
 const ClientTaskList = (): React.ReactElement => {
-  const { tasks, reorderTask } = useTaskStore();
+  const { tasks, reorderTask, currentTagId } = useTaskStore();
   const { userId, setUserId } = useStore();
   const { isLinking } = useNoteStore();
   const [loading, setLoading] = React.useState(true);
+
+  // Filter tasks in memory based on the current tag
+  const filteredTasks = React.useMemo(() => {
+    if (currentTagId) {
+      return tasks.filter((task) =>
+        task.taskTags.some((tag) => tag.tagId === currentTagId)
+      );
+    }
+    return tasks;
+  }, [tasks, currentTagId]);
 
   //TODO: better classes - clsx?
   const listPadding = isLinking ? 'py-2 px-4' : '';
@@ -103,7 +113,7 @@ const ClientTaskList = (): React.ReactElement => {
             strategy={verticalListSortingStrategy}
           >
             <ul className={`${listPadding} ${listBorder}`}>
-              {tasks.map((task) => (
+              {filteredTasks.map((task) => (
                 <SortableTaskItem key={task.id} task={task} />
               ))}
             </ul>

--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -37,19 +37,17 @@ import { getSession } from 'next-auth/react';
  * @returns {React.ReactElement} A JSX element representing the task list.
  */
 const ClientTaskList = (): React.ReactElement => {
-  const { tasks, reorderTask, currentTagId, loadingTasks } = useTaskStore();
+  const { tasks, reorderTask, selectedTagIds, loadingTasks } = useTaskStore();
   const { userId, setUserId } = useStore();
   const { isLinking } = useNoteStore();
 
   // Filter tasks in memory based on the current tag
   const filteredTasks = React.useMemo(() => {
-    if (currentTagId) {
-      return tasks.filter((task) =>
-        task.taskTags.some((tag) => tag.tagId === currentTagId)
-      );
-    }
-    return tasks;
-  }, [tasks, currentTagId]);
+    if (selectedTagIds.length === 0) return tasks; // no filtering
+    return tasks.filter((task) =>
+      task.taskTags.some((taskTag) => selectedTagIds.includes(taskTag.tagId))
+    );
+  }, [tasks, selectedTagIds]);
 
   //TODO: better classes - clsx?
   const listPadding = isLinking ? 'py-2 px-4' : '';

--- a/app/components/ClientTaskList/SortableTaskItem.tsx
+++ b/app/components/ClientTaskList/SortableTaskItem.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Task } from '@/lib/db';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import TaskItem from './TaskItem/TaskItem';
+import type { TaskWithTags } from '@/lib/store/task';
 // SEE DOCS: https://docs.dndkit.com/presets/sortable
 
 /**
@@ -15,7 +15,11 @@ import TaskItem from './TaskItem/TaskItem';
  * @param {Task} props.task The task to render.
  * @returns {React.ReactElement} A JSX element representing the sortable task list item.
  */
-const SortableTaskItem = ({ task }: { task: Task }): React.ReactElement => {
+const SortableTaskItem = ({
+  task,
+}: {
+  task: TaskWithTags;
+}): React.ReactElement => {
   // useSortable provides utils to make the elements sortable
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({

--- a/app/components/ClientTaskList/TaskItem/DueDateModal.tsx
+++ b/app/components/ClientTaskList/TaskItem/DueDateModal.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import Modal from '../../Modal/Modal';
-import { Task } from '@/lib/db';
 import { useTaskStore } from '@/lib/store/task';
+import type { TaskWithTags } from '@/lib/store/task';
 
 type DueDateModalProps = {
   isDueDateModalOpen: boolean;
   setIsDueDateModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  task: Task;
+  task: TaskWithTags;
 };
 
 const DueDateModal = ({

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { Task } from '@/lib/db';
 import { COLORS } from '@/utils/constants';
 import { useTaskStore } from '@/lib/store/task';
 import { useNoteStore } from '@/lib/store/note';
@@ -9,6 +8,7 @@ import { useSelectedTaskStore } from '@/lib/store/selected.task';
 import DueDateModal from './DueDateModal';
 import MeatballMenu from '../../MeatballMenu';
 import ToggleCompletionButton from './ToggleCompletionButton';
+import type { TaskWithTags } from '@/lib/store/task';
 
 /**
  * A component to render a single task.
@@ -17,7 +17,7 @@ import ToggleCompletionButton from './ToggleCompletionButton';
  * @param {Task} props.task The task to render.
  * @returns {React.ReactElement} A JSX element representing the task list item.
  */
-const TaskItem = ({ task }: { task: Task }): React.ReactElement => {
+const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDueDateModalOpen, setIsDueDateModalOpen] = useState(false);
   const { deleteTask, toggleComplete } = useTaskStore();

--- a/app/components/LoadingSpinner.tsx
+++ b/app/components/LoadingSpinner.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const LoadingSpinner = () => {
+  return (
+    <div className="flex justify-center items-center h-20">
+      <div className="w-10 h-10 border-4 border-gray-300 border-t-primary rounded-full animate-spin"></div>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/app/components/TasksToolbar.tsx/TagItem.tsx
+++ b/app/components/TasksToolbar.tsx/TagItem.tsx
@@ -3,7 +3,7 @@ import { Tag } from '@/lib/db';
 import { COLORS } from '@/utils/constants';
 
 type TagSortingProps = {
-  currentTagId: string | null;
+  selectedTagIds: string[];
   handleTagChange: (tagId: string) => void;
   tag: Tag;
 };
@@ -17,7 +17,8 @@ type TagSortingProps = {
  *
  * @param {TagSortingProps} props - The props for the component.
  */
-const TagItem = ({ tag, currentTagId, handleTagChange }: TagSortingProps) => {
+const TagItem = ({ tag, selectedTagIds, handleTagChange }: TagSortingProps) => {
+  const isSelected = selectedTagIds.includes(tag.id);
   const bgColor = tag.color
     ? COLORS.find((color) => color.name === tag.color)?.class
     : 'bg-note';
@@ -29,7 +30,7 @@ const TagItem = ({ tag, currentTagId, handleTagChange }: TagSortingProps) => {
       key={tag.id}
       className={`
                 p-2 rounded-full font-medium shadow ${bgColor} ${textColor} ${
-        currentTagId === tag.id
+        isSelected
           ? 'border-2 border-highlight font-bold'
           : 'border-2 border-transparent'
       }`}

--- a/app/components/TasksToolbar.tsx/TasksToolbar.tsx
+++ b/app/components/TasksToolbar.tsx/TasksToolbar.tsx
@@ -8,20 +8,21 @@ import AddTagModal from './AddTagModal';
 
 const TasksToolbar = () => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const { selectAllTasks, deleteSelectedTasks, setCurrentTagId, currentTagId } =
-    useTaskStore();
+  const {
+    selectAllTasks,
+    deleteSelectedTasks,
+    setSelectedTagId,
+    selectedTagIds,
+    clearSelectedTags,
+  } = useTaskStore();
   const { selectedTaskIds, clearSelectedTaskIds } = useSelectedTaskStore();
   const { isLinking } = useNoteStore();
   const { tags } = useTagStore();
 
   const handleTagChange = (tagId: string) => {
+    // now we can have more than 1
     clearSelectedTaskIds();
-    // if the tagId is the same as the currentTagId, reset the currentTagId
-    if (tagId === currentTagId) {
-      setCurrentTagId(null);
-      return;
-    }
-    setCurrentTagId(tagId);
+    setSelectedTagId(tagId);
   };
 
   return (
@@ -30,14 +31,25 @@ const TasksToolbar = () => {
         <div>
           <div className="flex items-center justify-between">
             <p className="font-bold text-text text-lg">Filter by Tag</p>
-            <button
-              className="bg-primary rounded disabled:bg-gray-400 hover:bg-secondary
+            <div className="flex gap-2">
+              <button
+                className="bg-highlight rounded disabled:bg-gray-400 hover:bg-secondary
         text-white p-2 font-semibold
         "
-              onClick={() => setIsModalOpen(true)}
-            >
-              + Add a Tag
-            </button>
+                onClick={() => clearSelectedTags()}
+                disabled={selectedTagIds.length === 0}
+              >
+                Clear Filters
+              </button>
+              <button
+                className="bg-primary rounded disabled:bg-gray-400 hover:bg-secondary
+        text-white p-2 font-semibold
+        "
+                onClick={() => setIsModalOpen(true)}
+              >
+                + Add a Tag
+              </button>
+            </div>
           </div>
         </div>
         <div className="flex gap-1">
@@ -45,7 +57,7 @@ const TasksToolbar = () => {
             <TagItem
               key={tag.id}
               tag={tag}
-              currentTagId={currentTagId}
+              selectedTagIds={selectedTagIds}
               handleTagChange={handleTagChange}
             />
           ))}
@@ -93,7 +105,6 @@ const TasksToolbar = () => {
             </button> */}
             {isModalOpen && (
               <AddTagModal
-                //task={task}
                 isModalOpen={isModalOpen}
                 setIsModalOpen={setIsModalOpen}
               />

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -25,8 +25,12 @@ interface TaskStore {
   selectAllTasks: () => void;
   updateTaskDueDate: (id: string, dueDate: Date) => void;
   // Tag management
-  currentTagId: string | null;
-  setCurrentTagId: (tagId: string | null) => void;
+  //currentTagId: string | null;
+  // TODO: this could all be it's own store
+  selectedTagIds: string[];
+  // setSelectedTagId - before
+  setSelectedTagId: (tagId: string) => void;
+  clearSelectedTags: () => void;
 }
 
 export const useTaskStore = create<TaskStore>()(
@@ -34,7 +38,20 @@ export const useTaskStore = create<TaskStore>()(
     (set, get) => ({
       tasks: [],
       loadingTasks: false,
-      currentTagId: null,
+      selectedTagIds: [],
+      clearSelectedTags: () => {
+        set({ selectedTagIds: [] });
+      },
+      setSelectedTagId: (tagId) => {
+        set((state) => {
+          const isTagSelected = state.selectedTagIds.includes(tagId);
+          return {
+            selectedTagIds: isTagSelected
+              ? state.selectedTagIds.filter((id) => id !== tagId) // Remove if the tag is already in currentTagIds
+              : [...state.selectedTagIds, tagId], // Or add the new tagId
+          };
+        });
+      },
       fetchTasks: async () => {
         set({ loadingTasks: true });
         const userId = useStore.getState().userId;
@@ -77,13 +94,7 @@ export const useTaskStore = create<TaskStore>()(
           });
         }
       },
-      setCurrentTagId: (tagId) => {
-        set({ currentTagId: tagId });
-        // We won't trigger a refetch, we'll just sort in place
-        // trigger a re-fetch of tasks when the currentTagId changes
-        // TODO: Zustand research, there's probably a better way to trigger this refresh, without explicitly calling it
-        //useTaskStore.getState().fetchTasks();
-      },
+
       toggleComplete: async (id) => {
         // get the current completion status from the store
         const { tasks } = get();

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -16,6 +16,7 @@ export interface TaskWithTags extends Task {
 interface TaskStore {
   tasks: TaskWithTags[];
   fetchTasks: () => Promise<void>;
+  loadingTasks: boolean;
   addTask: (text: string, tagIds?: string[]) => void;
   deleteTask: (id: string) => void;
   deleteSelectedTasks: () => void;
@@ -32,8 +33,10 @@ export const useTaskStore = create<TaskStore>()(
   persist(
     (set, get) => ({
       tasks: [],
+      loadingTasks: false,
       currentTagId: null,
       fetchTasks: async () => {
+        set({ loadingTasks: true });
         const userId = useStore.getState().userId;
         if (!userId) return;
 
@@ -42,6 +45,7 @@ export const useTaskStore = create<TaskStore>()(
           const fetchedTasks = await taskService.getAllTasks(userId);
           // Set the tasks in the store
           set({ tasks: fetchedTasks });
+          set({ loadingTasks: false });
         } catch (error) {
           console.error('Failed to fetch tasks:', error);
         }
@@ -51,6 +55,7 @@ export const useTaskStore = create<TaskStore>()(
         if (!userId) return;
 
         const newTask = await taskService.addTask(text, userId, tagIds);
+
         if (!newTask) throw new Error('There was a problem adding the task');
 
         set((state) => ({ tasks: [...state.tasks, newTask] }));


### PR DESCRIPTION
## Changes 

- Allows multi tag filtering 
- Adds Clear Filters button 
- Updates filtering approach, removing it from the store and filtering in place/in memory in the ClientTaskList component. This way we avoid extraneous DB calls, and we don't get an odd UI flicker when we sort or add tasks
- Return task with tags from the POST route in api/tasks 
- Updates Task types with Prisma definitions 
- Adds a nice little loading spinner when fetching tasks 
