### PR TITLE
fix: wrap items on mobile, update select styles, fix colors

### DIFF
--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -12,6 +12,8 @@ export async function GET(req: NextRequest) {
     const tags = await prisma.tag.findMany({
       where: { userId },
       // include: { tasks: true }, // do we want this?
+      // order alphabetically
+      orderBy: { name: 'asc' },
     });
     return NextResponse.json(tags);
   } catch (error) {

--- a/app/components/AddTasks/AddTasks.tsx
+++ b/app/components/AddTasks/AddTasks.tsx
@@ -46,7 +46,7 @@ const AddTasks = () => {
         className="flex flex-col gap-2"
         onSubmit={handleFormSubmit}
       >
-        <div className="flex items-center border rounded-full px-4 py-2 bg-gray-100 gap-1">
+        <div className="flex items-center border rounded-full text-text px-4 py-2 bg-background gap-1 flex-wrap">
           <label htmlFor="task-input" className="sr-only">
             Task Description
           </label>
@@ -56,7 +56,7 @@ const AddTasks = () => {
             type="text"
             value={taskText}
             onChange={(e) => setTaskText(e.target.value)}
-            className="flex-grow rounded bg-transparent focus:outline focus:outline-highlight text-text-secondary"
+            className="rounded flex-grow bg-transparent focus:outline focus:outline-highlight text-text-secondary"
             placeholder="Describe your task..."
           />
           <TagSelector
@@ -64,6 +64,7 @@ const AddTasks = () => {
             onTagSelect={(tag: string) => setTaskTag(tag)}
           />
         </div>
+
         <div className="flex gap-2">
           <button
             className="w-full text-center font-bold py-2 px-4 rounded-md

--- a/app/components/AddTasks/TagSelector.tsx
+++ b/app/components/AddTasks/TagSelector.tsx
@@ -11,15 +11,15 @@ const TagSelector = ({
 }) => {
   const { tags } = useTagStore();
 
+  if (tags.length === 0) return null;
+
   return (
-    <>
-      <label htmlFor="tag" className="sr-only">
-        Select a tag for the task
-      </label>
+    <div className="relative w-min">
       <select
         name="select task tag"
+        aria-label="Select a tag for the task"
         id="tag"
-        className="bg-gray-100 focus:outline text-text-secondary text-sm focus:outline-highlight rounded-full"
+        className="bg-background border focus:outline text-text font-semibold text-sm focus:outline-highlight rounded-full appearance-none px-2 py-1 pr-6"
         value={selectedTag}
         onChange={(e) => onTagSelect(e.target.value)}
       >
@@ -30,7 +30,21 @@ const TagSelector = ({
           </option>
         ))}
       </select>
-    </>
+      <div className="absolute inset-y-0 right-2 text-text flex items-center pointer-events-none">
+        <svg
+          className="w-4 h-4 text-text"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
   );
 };
 

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -26,14 +26,12 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   const { isLinking } = useNoteStore();
   const { disableColorCodeTasks } = useStore();
 
-  const taskTagColor =
-    task.taskTags.length > 0 && !disableColorCodeTasks
-      ? task.taskTags[0].tag.color
-      : 'green';
+  const taskTagColor = task.taskTags.length > 0 && task.taskTags[0].tag.color;
 
-  const bgColor = COLORS.find(
-    (color) => color.name === taskTagColor
-  )?.background;
+  const bgColor =
+    task.taskTags.length > 0 && !disableColorCodeTasks
+      ? COLORS.find((color) => color.name === taskTagColor)?.background
+      : 'bg-note';
 
   // TODO - better classes - clsx?
   const borderColor = selectedTaskIds.includes(task.id)

--- a/app/components/TasksToolbar.tsx/TasksToolbar.tsx
+++ b/app/components/TasksToolbar.tsx/TasksToolbar.tsx
@@ -45,7 +45,7 @@ const TasksToolbar = () => {
             <p className="font-bold text-text text-lg">Filter by Tag</p>
           </div>
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-1 flex-wrap">
           {tags.map((tag) => (
             <TagItem
               key={tag.id}
@@ -84,7 +84,7 @@ const TasksToolbar = () => {
                 Disable Color Coding
               </label>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap">
               <button
                 className={buttonClass}
                 onClick={() => setIsModalOpen(true)}

--- a/app/components/TextEditor/TextEditor.tsx
+++ b/app/components/TextEditor/TextEditor.tsx
@@ -59,7 +59,7 @@ const TextEditor = () => {
   return (
     <div className="rounded-md p4 mt-6">
       <Toolbar editor={editor} />
-      <div className="border rounded-md p-2">
+      <div className="border rounded-md p-2 bg-background text-text">
         <label id="editor-label" className="sr-only">
           Write your note here...
         </label>

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -15,7 +15,7 @@ import { auth } from '@/auth';
 async function Header() {
   const session = await auth();
   return (
-    <header className="sticky top-0 bg-primary p-4 px-6 shadow-md flex justify-between items-center z-10">
+    <header className="sticky top-0 bg-primary p-4 px-6 shadow-md flex justify-between items-center flex-wrap z-10">
       <h1 className="text-lg font-bold text-text">HabitNest</h1>
       <div className="flex items-center space-x-4">
         <ThemeSwitcher />

--- a/app/components/layout/ThemeSwitcher.tsx
+++ b/app/components/layout/ThemeSwitcher.tsx
@@ -22,20 +22,36 @@ const ThemeSwitcher = (): JSX.Element => {
   };
 
   return (
-    <select
-      name="theme"
-      aria-label="Theme Selector"
-      id="theme-selector"
-      value={theme}
-      onChange={handleThemeChange}
-      className="text-gray-900 p-2 rounded focus:outline focus:outline-highlight"
-    >
-      {AVAILABLE_THEMES.map((theme) => (
-        <option key={theme} value={theme}>
-          {THEMES[theme]}
-        </option>
-      ))}
-    </select>
+    <div className="relative">
+      <select
+        name="theme"
+        aria-label="Theme Selector"
+        id="theme-selector"
+        value={theme}
+        onChange={handleThemeChange}
+        className="text-gray-900 p-2 pr-8 rounded bg-background focus:outline font-semibold text-text focus:outline-highlight appearance-none"
+      >
+        {AVAILABLE_THEMES.map((theme) => (
+          <option key={theme} value={theme}>
+            {THEMES[theme]}
+          </option>
+        ))}
+      </select>
+      <div className="absolute inset-y-0 right-2 text-text flex items-center pointer-events-none">
+        <svg
+          className="w-4 h-4 text-text"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
   );
 };
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,7 @@
   --color-primary: #21a0a0;
   --color-secondary: #046865;
   --color-text: #074846;
-  --color-note: #e9f7ee;
+  --color-note: #bbe9cb;
   --color-highlight: #41d070;
   --color-modal: #e9f7ee;
   --color-utility: #d1f0dc;


### PR DESCRIPTION
## Changes 

This PR fixes up a host of things I was aware of, but putting off fixing. 

- Tags wrap on small screens 
- Add task input doesn't run over on small screens anymore 
- Updates the theme and tag `<selects>` and styles them a little more nicely 
- Makes sure that color assignments make it into places it was missing - like the `<textarea>` for notes 