### PR TITLE
feat: add user stats section, minor fixes

### DIFF
--- a/app/components/DashboardGreeting.tsx
+++ b/app/components/DashboardGreeting.tsx
@@ -1,22 +1,23 @@
 'use client';
 
 import React, { useEffect, useState, type JSX } from 'react';
+import { useStatStore } from '@/lib/store/stat';
 
-// TODO: Enrich with user data
+//TODO: Think on the appearance of this section more - design something in Figma
+
+const statContainerStyles =
+  'bg-utility rounded p-2 text-xs font-semibold text-text shadow-sm';
 
 /**
- * A React component that displays a personalized greeting message
- * based on the current time of day.
+ * A component that displays a greeting message to the user, based on the time of day
+ * and a couple of statistics about their task completion.
  *
- * The component uses the `useEffect` hook to determine the current
- * hour and sets a greeting message accordingly. It greets the user
- * with "Good morning", "Good afternoon", or "Good evening" based on
- * the time of day. The message is displayed alongside a bolded name.
- *
- * @returns {JSX.Element} A JSX element containing the greeting message.
+ * @param {{ username: string }} props The username to display in the greeting message
+ * @returns {JSX.Element} A JSX element representing the greeting message
  */
 const DashboardGreeting = ({ username }: { username: string }): JSX.Element => {
   const [message, setMessage] = useState('');
+  const { completedThisWeek, completedToday } = useStatStore();
 
   useEffect(() => {
     const time = new Date().getHours();
@@ -30,10 +31,24 @@ const DashboardGreeting = ({ username }: { username: string }): JSX.Element => {
   }, []);
 
   return (
-    <div>
+    <div className="flex flex-col gap-2 w-[100%]">
       <p className="text-2xl">
         {message} <span className="font-bold">{username}</span>
       </p>
+      <div className="flex gap-4 p-2">
+        <div className={statContainerStyles}>
+          <p>Completed Today</p>
+          <div className="flex justify-center p-1">
+            <p className="text-lg">{completedToday}</p>
+          </div>
+        </div>
+        <div className={statContainerStyles}>
+          <p>Completed this Week</p>
+          <div className="flex justify-center p-1">
+            <p className="text-lg">{completedThisWeek}</p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/lib/store/stat.ts
+++ b/lib/store/stat.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+import { useTaskStore } from './task';
+import moment from 'moment';
+
+interface StatStore {
+  currentDay: Date;
+  currentWeek: number;
+  completedToday: number;
+  completedThisWeek: number;
+  updateStats: () => void;
+}
+
+export const useStatStore = create<StatStore>((set) => ({
+  currentDay: new Date(),
+  currentWeek: moment().isoWeek(), // ISO week number
+  completedToday: 0,
+  completedThisWeek: 0,
+  updateStats: () => {
+    const { tasks } = useTaskStore.getState();
+    // Define the start of today to use for date comparisons
+    const today = moment().startOf('day');
+    // Get the current ISO week number for tracking weekly tasks
+    // this will help us introduce monthly tracking
+    const currentWeek = moment().isoWeek();
+
+    const completedToday = tasks.filter(
+      (task) =>
+        // Check if dateUpdated matches today's date - task was completed today
+        task.completed &&
+        task.dateUpdated &&
+        moment(task.dateUpdated).isSame(today, 'day')
+    ).length;
+
+    const completedThisWeek = tasks.filter(
+      // Check if dateUpdated falls into the current ISO week number - task was completed this week
+      (task) =>
+        task.completed &&
+        task.dateUpdated &&
+        moment(task.dateUpdated).isoWeek() === currentWeek
+    ).length;
+
+    set({
+      currentDay: new Date(),
+      currentWeek,
+      completedToday,
+      completedThisWeek,
+    });
+  },
+}));
+
+// Subscribe to task store updates - we can probably use this to replace onRehydrateStorage calls
+useTaskStore.subscribe(() => {
+  useStatStore.getState().updateStats();
+});

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -28,7 +28,6 @@ interface TaskStore {
   //currentTagId: string | null;
   // TODO: this could all be it's own store
   selectedTagIds: string[];
-  // setSelectedTagId - before
   setSelectedTagId: (tagId: string) => void;
   clearSelectedTags: () => void;
 }
@@ -116,21 +115,51 @@ export const useTaskStore = create<TaskStore>()(
           });
         }
       },
-
+      /**
+       * Toggles the completion of a task.
+       *
+       * @param {string} id The ID of the task to toggle completion on.
+       *
+       * This function will first update the state of the task in the store to reflect the new completion status.
+       * It will then call the `toggleComplete` function from the `taskService` to update the task in the database.
+       *
+       * If the call to the database fails, it will revert the state of the task in the store to what it was before the toggle.
+       */
       toggleComplete: async (id) => {
         const userId = useStore.getState().userId;
         if (!userId) return;
-        const { tasks } = get();
-        const task = tasks.find((task) => task.id === id);
-        if (!task) return;
-        const taskCompleted = task.completed || false;
-        await taskService.toggleComplete(id, userId, !taskCompleted);
 
+        const { tasks } = get();
+        set({ loadingTasks: true });
+        const task = tasks.find((task) => task.id === id);
+
+        if (!task) {
+          set({ loadingTasks: false });
+          return;
+        }
+
+        const taskCompleted = task.completed || false;
+        // Update state before the DB call for a snappier UI feel
         set((state) => ({
           tasks: state.tasks.map((task) =>
             task.id === id ? { ...task, completed: !task.completed } : task
           ),
         }));
+        const res = await taskService.toggleComplete(
+          id,
+          userId,
+          !taskCompleted
+        );
+        if (!res.ok) {
+          console.warn(`Error toggling completion for task: ${task.id}`);
+          // If toggling complete fails in the database - revert store state
+          set((state) => ({
+            tasks: state.tasks.map((task) =>
+              task.id === id ? { ...task, completed: task.completed } : task
+            ),
+          }));
+        }
+        set({ loadingTasks: false });
       },
       updateTaskDueDate: async (id, dueDate) => {
         await taskService.updateTaskDueDate(id, dueDate);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "bcryptjs": "^2.4.3",
         "classnames": "^2.5.1",
         "dexie": "^4.0.10",
+        "moment": "^2.30.1",
         "next": "15.1.5",
         "next-auth": "^5.0.0-beta.25",
         "prisma": "^6.2.1",
@@ -7876,6 +7877,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bcryptjs": "^2.4.3",
     "classnames": "^2.5.1",
     "dexie": "^4.0.10",
+    "moment": "^2.30.1",
     "next": "15.1.5",
     "next-auth": "^5.0.0-beta.25",
     "prisma": "^6.2.1",

--- a/tests/TaskToolbar.test.tsx
+++ b/tests/TaskToolbar.test.tsx
@@ -51,8 +51,8 @@ jest.mock('@/lib/store/task', () => ({
     ],
     selectAllTasks: jest.fn(),
     deleteSelectedTasks: jest.fn(),
-    setCurrentTagId: jest.fn(),
-    currentTagId: null,
+    setSelectedTagId: jest.fn(),
+    selectedTagIds: [],
   })),
 }));
 


### PR DESCRIPTION
## Changes 

Adds user 'stat' section 

<img width="606" alt="image" src="https://github.com/user-attachments/assets/1f43ce88-6b36-4ed7-9c9f-295502ab544c" />

This is far from how I see it actually looking in the end, but I wanted to get some of these pieces in as we continue fleshing this out and migrating storage to Prisma and RDS. 

Fixes some minor stuff up -
- Fix failing TaskToolbar test 
- Refactor toggling - we now immediately update the store state so that the UI doesn't lag if it takes some time to update the completion in the database 