### PR TITLE
feat: Adds Weekly Planner page

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -66,7 +66,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const { text, userId, tagIds } = body;
+  const { text, userId, tagIds, taskDueDate } = body;
 
   if (!text || !userId) {
     return NextResponse.json(
@@ -89,6 +89,7 @@ export async function POST(req: NextRequest) {
         text,
         userId,
         position: newTaskPosition,
+        dueDate: taskDueDate,
       },
     });
 

--- a/app/components/ClientTaskList/ClientTaskList.tsx
+++ b/app/components/ClientTaskList/ClientTaskList.tsx
@@ -21,7 +21,7 @@ import LoadingSpinner from '../LoadingSpinner';
 import SortableTaskItem from './SortableTaskItem';
 import TasksToolbar from '../TasksToolbar.tsx';
 import { getSession } from 'next-auth/react';
-
+// import PomodoroTimer from '../Timer';
 /**
  * A component that renders a draggable and sortable list of tasks.
  *
@@ -107,6 +107,9 @@ const ClientTaskList = (): React.ReactElement => {
       <h2 className="text-text text-2xl font-bold mb-4">Your Tasks</h2>
       <div className="flex flex-col gap-4">
         <TasksToolbar />
+        {/* <PomodoroTimer
+          expiryTimestamp={new Date(Date.now() + 25 * 60 * 1000)}
+        /> */}
         <DndContext
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { COLORS } from '@/utils/constants';
 import { useTaskStore } from '@/lib/store/task';
 import { useNoteStore } from '@/lib/store/note';
+import { useStatStore } from '@/lib/store/stat';
 import { useStore } from '@/lib/store/app';
 import { useSelectedTaskStore } from '@/lib/store/selected.task';
 import DueDateModal from './DueDateModal';
@@ -22,6 +23,7 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDueDateModalOpen, setIsDueDateModalOpen] = useState(false);
   const { deleteTask, toggleComplete } = useTaskStore();
+  const { updateStats } = useStatStore();
   const { selectedTaskIds, setSelectedTaskIds } = useSelectedTaskStore();
   const { isLinking } = useNoteStore();
   const { disableColorCodeTasks } = useStore();
@@ -40,6 +42,11 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
 
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
+  };
+
+  const toggleCompleteTask = (id: string) => {
+    toggleComplete(id);
+    updateStats();
   };
 
   const menuItems = [
@@ -98,7 +105,7 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
       <div className="flex items-center">
         <ToggleCompletionButton
           isCompleted={task.completed}
-          onToggle={() => toggleComplete(task.id)}
+          onToggle={() => toggleCompleteTask(task.id)}
         />
         <MeatballMenu
           menuOpen={menuOpen}

--- a/app/components/DashboardGreeting.tsx
+++ b/app/components/DashboardGreeting.tsx
@@ -25,7 +25,7 @@ const DashboardGreeting = ({ username }: { username: string }): JSX.Element => {
   }, []);
 
   return (
-    <div className="flex flex-col gap-2 w-[100%]">
+    <div className="flex flex-col gap-2">
       <p className="text-2xl">
         {message} <span className="font-bold">{username}</span>
       </p>

--- a/app/components/DashboardGreeting.tsx
+++ b/app/components/DashboardGreeting.tsx
@@ -1,13 +1,8 @@
 'use client';
 
 import React, { useEffect, useState, type JSX } from 'react';
-import { useStatStore } from '@/lib/store/stat';
 
 //TODO: Think on the appearance of this section more - design something in Figma
-
-const statContainerStyles =
-  'bg-utility rounded p-2 text-xs font-semibold text-text shadow-sm';
-
 /**
  * A component that displays a greeting message to the user, based on the time of day
  * and a couple of statistics about their task completion.
@@ -17,7 +12,6 @@ const statContainerStyles =
  */
 const DashboardGreeting = ({ username }: { username: string }): JSX.Element => {
   const [message, setMessage] = useState('');
-  const { completedThisWeek, completedToday } = useStatStore();
 
   useEffect(() => {
     const time = new Date().getHours();
@@ -35,20 +29,6 @@ const DashboardGreeting = ({ username }: { username: string }): JSX.Element => {
       <p className="text-2xl">
         {message} <span className="font-bold">{username}</span>
       </p>
-      <div className="flex gap-4 p-2">
-        <div className={statContainerStyles}>
-          <p>Completed Today</p>
-          <div className="flex justify-center p-1">
-            <p className="text-lg">{completedToday}</p>
-          </div>
-        </div>
-        <div className={statContainerStyles}>
-          <p>Completed this Week</p>
-          <div className="flex justify-center p-1">
-            <p className="text-lg">{completedThisWeek}</p>
-          </div>
-        </div>
-      </div>
     </div>
   );
 };

--- a/app/components/DashboardStats.tsx
+++ b/app/components/DashboardStats.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { useStatStore } from '@/lib/store/stat';
+
+const statContainerStyles =
+  'bg-utility rounded p-2 text-xs font-semibold text-text shadow-sm';
+
+const DashboardStats = () => {
+  const {
+    completedThisWeek,
+    completedToday,
+    dueThisWeek,
+    dueToday,
+    completedDueThisWeek,
+    completedDueToday,
+  } = useStatStore();
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-2">
+      <div className={statContainerStyles}>
+        <p>Today</p>
+        <div className="flex justify-center p-1">
+          <p className="text-lg">{completedToday}</p>
+        </div>
+      </div>
+      <div className={statContainerStyles}>
+        <p>This Week</p>
+        <div className="flex justify-center p-1">
+          <p className="text-lg">{completedThisWeek}</p>
+        </div>
+      </div>
+      <div className={statContainerStyles}>
+        <p>Due Today</p>
+        <div className="flex justify-center items-center p-1">
+          <p className="text-lg">{completedDueToday}</p>
+          <span className="font-light mx-1">/</span>
+          <p className="text-lg font-light">{dueToday}</p>
+        </div>
+      </div>
+      <div className={statContainerStyles}>
+        <p>Due this Week</p>
+        <div className="flex justify-center items-center p-1">
+          <p className="text-lg">{completedDueThisWeek}</p>
+          <span className="font-light mx-1">/</span>
+          <p className="text-lg font-light">{dueThisWeek}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardStats;

--- a/app/components/Timer/PomodoroTimer.tsx
+++ b/app/components/Timer/PomodoroTimer.tsx
@@ -1,0 +1,30 @@
+import { useTimer } from 'react-timer-hook';
+
+const PomodoroTimer = ({ expiryTimestamp }: { expiryTimestamp: Date }) => {
+  const { seconds, minutes, start, pause, restart } = useTimer({
+    expiryTimestamp,
+    autoStart: false,
+  });
+
+  return (
+    <div className="p-4 bg-gray-800 text-white rounded-lg">
+      <div className="text-2xl">
+        {minutes}:{seconds < 10 ? `0${seconds}` : seconds}
+      </div>
+      <button onClick={start} className="m-1 p-1 bg-green-500 rounded">
+        Start
+      </button>
+      <button onClick={pause} className="m-1 p-1 bg-yellow-500 rounded">
+        Pause
+      </button>
+      <button
+        onClick={() => restart(new Date(Date.now() + 25 * 60 * 1000))}
+        className="m-1 p-1 bg-blue-500 rounded"
+      >
+        Restart
+      </button>
+    </div>
+  );
+};
+
+export default PomodoroTimer;

--- a/app/components/Timer/index.ts
+++ b/app/components/Timer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PomodoroTimer';

--- a/app/components/forms/PlannerForm.tsx
+++ b/app/components/forms/PlannerForm.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { useTaskStore } from '@/lib/store/task';
 import TagSelector from '../AddTasks/TagSelector';
 
-interface PlannerTask {
+export interface PlannerTask {
   text: string;
   date?: string;
   tag?: string;
@@ -180,7 +180,11 @@ const PlannerForm = () => {
           </div>
         )}
 
-        <button type="submit" className="bg-primary text-white p-2 rounded">
+        <button
+          type="submit"
+          className="text-center font-bold py-2 px-4 rounded-md
+        bg-primary hover:bg-secondary text-white disabled:bg-gray-400"
+        >
           Save Tasks
         </button>
       </form>

--- a/app/components/forms/PlannerForm.tsx
+++ b/app/components/forms/PlannerForm.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTaskStore } from '@/lib/store/task';
+import TagSelector from '../AddTasks/TagSelector';
+
+interface PlannerTask {
+  text: string;
+  date?: string;
+  tag?: string;
+}
+
+type SectionKeys = 'contact' | 'schedule' | 'followUp' | 'research' | 'create';
+
+type Sections = Record<SectionKeys, PlannerTask[]>;
+
+const PlannerForm = () => {
+  const { addTask } = useTaskStore();
+  const [bigGoal, setBigGoal] = useState('');
+  const [priorities, setPriorities] = useState<PlannerTask[]>([]);
+  const [sections, setSections] = useState<Sections>({
+    contact: [{ text: '', date: '', tag: '' }],
+    schedule: [{ text: '', date: '', tag: '' }],
+    followUp: [{ text: '', date: '', tag: '' }],
+    research: [{ text: '', date: '', tag: '' }],
+    create: [{ text: '', date: '', tag: '' }],
+  });
+
+  const handleChange = (
+    section: SectionKeys,
+    index: number,
+    field: keyof PlannerTask,
+    value: string
+  ) => {
+    setSections((prev) => {
+      const updated = { ...prev };
+      updated[section][index][field] = value;
+      return { ...updated };
+    });
+  };
+
+  const addField = (section: SectionKeys) => {
+    setSections((prev) => ({
+      ...prev,
+      [section]: [...prev[section], { text: '', date: '', tag: '' }],
+    }));
+  };
+
+  const togglePriority = (section: SectionKeys, index: number) => {
+    const item = sections[section][index];
+    // if there's no text, don't toggle
+    if (!item.text) return;
+    setPriorities((prev) => {
+      if (prev.includes(item)) {
+        return prev.filter((p) => p !== item);
+      }
+      return [...prev, item];
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    Object.entries(sections).forEach(([, items]) => {
+      items.forEach(async (item) => {
+        console.log(item);
+        if (item.text.trim()) {
+          await addTask(item.text, item.tag ? [item.tag] : [], item.date);
+        }
+      });
+    });
+    setBigGoal('');
+    setSections({
+      contact: [{ text: '', tag: '', date: '' }],
+      schedule: [{ text: '', date: '', tag: '' }],
+      followUp: [{ text: '', tag: '', date: '' }],
+      research: [{ text: '', tag: '', date: '' }],
+      create: [{ text: '', tag: '', date: '' }],
+    });
+    setPriorities([]);
+  };
+
+  return (
+    <main className="p-6 bg-note text-textSecondary rounded shadow">
+      <h1 className="text-2xl font-bold">Weekly Planner</h1>
+      <p>
+        This is a place to plan your week from a high-level. Add tasks, organize
+        them with tags, by date, and priority.
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-2 mt-4">
+        <label className="block text-lg font-medium">My Big Goal</label>
+        <p className="text-sm">
+          What is your most important goal for this week?
+        </p>
+        <input
+          type="text"
+          value={bigGoal}
+          onChange={(e) => setBigGoal(e.target.value)}
+          className="w-full p-2 border rounded"
+          placeholder="Describe your most important goal for this week..."
+        />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 pt-4">
+          {Object.entries(sections).map(([section, items]) => (
+            <div key={section} className="space-y-2">
+              <h2 className="font-semibold">
+                This week I need to{' '}
+                <span>{section.replace(/([A-Z])/g, ' $1')}</span> ...
+              </h2>
+              {items.map((item, index) => (
+                <div
+                  key={index}
+                  className="flex gap-2 items-center bg-primary p-2 rounded shadow-sm"
+                >
+                  <input
+                    type="text"
+                    value={item.text}
+                    onChange={(e) =>
+                      handleChange(
+                        section as SectionKeys,
+                        index,
+                        'text',
+                        e.target.value
+                      )
+                    }
+                    className="p-2 border rounded w-full"
+                    placeholder="Task"
+                  />
+                  <input
+                    type="date"
+                    value={item.date}
+                    onChange={(e) =>
+                      handleChange(
+                        section as SectionKeys,
+                        index,
+                        'date',
+                        e.target.value
+                      )
+                    }
+                    className="p-2 border rounded w-1/4"
+                  />
+                  <TagSelector
+                    selectedTag={item.tag || ''}
+                    onTagSelect={(tag) =>
+                      handleChange(section as SectionKeys, index, 'tag', tag)
+                    }
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      togglePriority(section as SectionKeys, index)
+                    }
+                    className={`p-2 rounded ${
+                      priorities.includes(item)
+                        ? 'bg-yellow-400'
+                        : 'bg-gray-200'
+                    }`}
+                  >
+                    ⭐
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => addField(section as SectionKeys)}
+                className="text-blue-500 mt-1"
+              >
+                + Add More
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {priorities.length > 0 && (
+          <div className="mt-6 p-4 border rounded bg-gray-100">
+            <h2 className="font-bold text-lg">Top Priorities</h2>
+            <ul className="list-disc list-inside">
+              {priorities.map((p, idx) => (
+                <li key={idx}>{p.text || ''}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <button type="submit" className="bg-primary text-white p-2 rounded">
+          Save Tasks
+        </button>
+      </form>
+    </main>
+  );
+};
+
+export default PlannerForm;

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import LogoutButton from './LogoutButton';
 import ThemeSwitcher from './ThemeSwitcher';
 import { auth } from '@/auth';
@@ -16,7 +17,9 @@ async function Header() {
   const session = await auth();
   return (
     <header className="sticky top-0 bg-primary p-4 px-6 shadow-md flex justify-between items-center flex-wrap z-10">
-      <h1 className="text-lg font-bold text-text">HabitNest</h1>
+      <h1 className="text-lg font-bold text-text">
+        <Link href="/dashboard">HabitNest</Link>
+      </h1>
       <div className="flex items-center space-x-4">
         <ThemeSwitcher />
         {session && <LogoutButton />}

--- a/app/components/layout/ThemeSwitcher.tsx
+++ b/app/components/layout/ThemeSwitcher.tsx
@@ -15,7 +15,7 @@ import { Theme, THEMES, AVAILABLE_THEMES } from '@/lib/core/theme.config';
  */
 const ThemeSwitcher = (): JSX.Element => {
   const { theme, setTheme } = useStore();
-
+  console.log('THEME', theme);
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const theme = e.target.value as Theme;
     setTheme(theme);

--- a/app/components/layout/ThemeSwitcher.tsx
+++ b/app/components/layout/ThemeSwitcher.tsx
@@ -15,7 +15,6 @@ import { Theme, THEMES, AVAILABLE_THEMES } from '@/lib/core/theme.config';
  */
 const ThemeSwitcher = (): JSX.Element => {
   const { theme, setTheme } = useStore();
-  console.log('THEME', theme);
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const theme = e.target.value as Theme;
     setTheme(theme);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import DashboardGreeting from '../components/DashboardGreeting';
 import DashboardStats from '../components/DashboardStats';
 import { auth } from '@/auth';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -19,30 +20,27 @@ export default async function DashboardPage() {
   return (
     <main>
       <div>
-        <div className="text-text px-4 py-6 flex justify-between">
-          <DashboardGreeting username={username} />
-          <DashboardStats />
-          {/** TODO: Make these into links, create a page for each */}
-          {/* <div className="flex gap-4">
-          <div>Monthly Calendar</div>
-          <div>Weekly Calendar</div>
-        </div> */}
+        <div className="text-text p-4 flex justify-between">
+          <div className="flex flex-col w-[100%]">
+            <div className="flex justify-between p-2">
+              <DashboardGreeting username={username} />
+              <Link
+                className="text-center font-bold py-2 px-4 rounded-md
+        bg-primary hover:bg-secondary text-white disabled:bg-gray-400"
+                href={'/plan/week'}
+              >
+                <button>Weekly Planner</button>
+              </Link>
+            </div>
+            <DashboardStats />
+          </div>
         </div>
-        {/** TODO: add dateCompleted and a way to assign tasks to a day */}
-        {/* <div className="text-text px-4 py-2">
-        <div>Tasks for the day (count)</div>
-      </div> */}
-        <div
-          className="h-screen text-black
-      grid gap-8 grid-cols-1 md:grid-cols-2
-      px-4 
-      "
-        >
-          <div className="flex flex-col">
+        <div className="h-screen text-black grid gap-2 grid-cols-1 md:grid-cols-2 px-4">
+          <div className="flex flex-col p-2">
             <ClientTaskList />
             <AddTasks />
           </div>
-          <div>
+          <div className="p-2">
             <NoteDisplay />
             <TextEditor />
           </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import ClientTaskList from '../components/ClientTaskList';
 import NoteDisplay from '../components/NoteBoard';
 import TextEditor from '../components/TextEditor';
 import DashboardGreeting from '../components/DashboardGreeting';
+import DashboardStats from '../components/DashboardStats';
 import { auth } from '@/auth';
 import { redirect } from 'next/navigation';
 
@@ -20,6 +21,7 @@ export default async function DashboardPage() {
       <div>
         <div className="text-text px-4 py-6 flex justify-between">
           <DashboardGreeting username={username} />
+          <DashboardStats />
           {/** TODO: Make these into links, create a page for each */}
           {/* <div className="flex gap-4">
           <div>Monthly Calendar</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,7 @@
   --color-primary: #21a0a0;
   --color-secondary: #046865;
   --color-text: #074846;
-  --color-note: #bbe9cb;
+  --color-note: #e9f7ee;
   --color-highlight: #41d070;
   --color-modal: #e9f7ee;
   --color-utility: #d1f0dc;

--- a/app/plan/week/page.tsx
+++ b/app/plan/week/page.tsx
@@ -1,0 +1,23 @@
+'use server';
+
+import PlannerForm from '../../components/forms/PlannerForm';
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+
+export default async function PlannerPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  return (
+    <main>
+      <div>
+        <div className="p-4">
+          <PlannerForm />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: local-mysql
     restart: always
     ports:
-      - '3306:3306' # Expose MySQL on localhost:3306
+      - '3308:3306' # Expose MySQL on localhost:3308
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: dev_db

--- a/lib/core/theme.config.ts
+++ b/lib/core/theme.config.ts
@@ -13,6 +13,6 @@ export const THEMES = {
 
 export type Theme = keyof typeof THEMES;
 
-export const DEFAULT_THEME: Theme = 'DeepSpace';
+export const DEFAULT_THEME: Theme = 'Tidepool';
 
 export const AVAILABLE_THEMES: Theme[] = Object.keys(THEMES) as Theme[];

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -28,14 +28,21 @@ export class TaskService {
       return [];
     }
   }
-  async addTask(text: string, userId: string, tagIds?: string[]) {
+  async addTask(
+    text: string,
+    userId: string,
+    tagIds?: string[],
+    date?: string
+  ) {
+    const taskDueDate = date ? new Date(date) : null;
+    console.log('TASK SERVICE: ', taskDueDate);
     try {
       const response = await fetch('/api/tasks', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ text, userId, tagIds }),
+        body: JSON.stringify({ text, userId, tagIds, taskDueDate }),
       });
 
       if (!response.ok) throw new Error('Failed to add task');

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -35,7 +35,6 @@ export class TaskService {
     date?: string
   ) {
     const taskDueDate = date ? new Date(date) : null;
-    console.log('TASK SERVICE: ', taskDueDate);
     try {
       const response = await fetch('/api/tasks', {
         method: 'POST',

--- a/lib/store/stat.ts
+++ b/lib/store/stat.ts
@@ -58,7 +58,7 @@ export const useStatStore = create<StatStore>((set) => ({
       }
 
       // If the task is complete and the UPDATED date is in the current week
-      if (task.completed && dueDate?.isoWeek() === currentWeek) {
+      if (task.completed && dateUpdated?.isoWeek() === currentWeek) {
         completedThisWeek++;
       }
 

--- a/lib/store/stat.ts
+++ b/lib/store/stat.ts
@@ -6,7 +6,12 @@ interface StatStore {
   currentDay: Date;
   currentWeek: number;
   completedToday: number;
+  // count for due today that are done
+  completedDueToday: number;
+  dueToday: number;
   completedThisWeek: number;
+  completedDueThisWeek: number;
+  dueThisWeek: number;
   updateStats: () => void;
 }
 
@@ -15,34 +20,68 @@ export const useStatStore = create<StatStore>((set) => ({
   currentWeek: moment().isoWeek(), // ISO week number
   completedToday: 0,
   completedThisWeek: 0,
+  dueToday: 0,
+  dueThisWeek: 0,
+  completedDueToday: 0,
+  completedDueThisWeek: 0,
   updateStats: () => {
     const { tasks } = useTaskStore.getState();
-    // Get the current ISO week number for tracking weekly tasks
-    // this will help us introduce monthly tracking
     const currentWeek = moment().isoWeek();
+    const today = moment();
 
-    const completedToday = tasks.filter(
-      (task) =>
-        // Check if dateUpdated matches today's date - task was completed today
-        task.completed &&
-        task.dateUpdated &&
-        // Can't use an outside variable here - value will become stale
-        moment(task.dateUpdated).isSame(moment(), 'day')
-    ).length;
+    // Init counters
+    let completedToday = 0;
+    let completedDueToday = 0;
+    let dueToday = 0;
+    let completedThisWeek = 0;
+    let completedDueThisWeek = 0;
+    let dueThisWeek = 0;
 
-    const completedThisWeek = tasks.filter(
-      // Check if dateUpdated falls into the current ISO week number - task was completed this week
-      (task) =>
-        task.completed &&
-        task.dateUpdated &&
-        moment(task.dateUpdated).isoWeek() === currentWeek
-    ).length;
+    tasks.forEach((task) => {
+      const dateUpdated = task.dateUpdated ? moment(task.dateUpdated) : null;
+      const dueDate = task.dueDate ? moment(task.dueDate) : null;
+
+      // Iterate the tasks once instead of in a series of filters
+      // If the task is complete and the UPDATED date is today
+      if (task.completed && dateUpdated?.isSame(today, 'day')) {
+        completedToday++;
+      }
+
+      // If the task is complete and the DUE date is today
+      if (task.completed && dueDate?.isSame(today, 'day')) {
+        completedDueToday++;
+      }
+
+      // If the DUE date is in the current day
+      if (dueDate?.isSame(today, 'day')) {
+        dueToday++;
+      }
+
+      // If the task is complete and the UPDATED date is in the current week
+      if (task.completed && dueDate?.isoWeek() === currentWeek) {
+        completedThisWeek++;
+      }
+
+      // If the task is complete and the DUE date is in the current week
+      if (task.completed && dueDate?.isoWeek() === currentWeek) {
+        completedDueThisWeek++;
+      }
+
+      // If the DUE date is in the current week
+      if (dueDate?.isoWeek() === currentWeek) {
+        dueThisWeek++;
+      }
+    });
 
     set({
       currentDay: new Date(),
       currentWeek,
       completedToday,
       completedThisWeek,
+      dueToday,
+      dueThisWeek,
+      completedDueToday,
+      completedDueThisWeek,
     });
   },
 }));

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -17,7 +17,7 @@ interface TaskStore {
   tasks: TaskWithTags[];
   fetchTasks: () => Promise<void>;
   loadingTasks: boolean;
-  addTask: (text: string, tagIds?: string[]) => void;
+  addTask: (text: string, tagIds?: string[], date?: string) => void;
   deleteTask: (id: string) => void;
   deleteSelectedTasks: () => void;
   toggleComplete: (id: string) => void;
@@ -65,12 +65,12 @@ export const useTaskStore = create<TaskStore>()(
           console.error('Failed to fetch tasks:', error);
         }
       },
-      addTask: async (text, tagIds) => {
+      addTask: async (text, tagIds, date) => {
+        console.table({ text, tagIds, date });
         const userId = useStore.getState().userId;
         if (!userId) return;
 
-        const newTask = await taskService.addTask(text, userId, tagIds);
-
+        const newTask = await taskService.addTask(text, userId, tagIds, date);
         if (!newTask) throw new Error('There was a problem adding the task');
 
         set((state) => ({ tasks: [...state.tasks, newTask] }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "react": "19.0.0",
         "react-confetti": "^6.2.2",
         "react-dom": "19.0.0",
+        "react-draggable": "^4.4.6",
+        "react-timer-hook": "^3.0.8",
         "uuid": "^11.0.3",
         "zustand": "^5.0.1"
       },
@@ -3860,6 +3862,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7390,8 +7401,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7659,7 +7669,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8758,7 +8767,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9046,11 +9054,33 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-timer-hook": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.8.tgz",
+      "integrity": "sha512-bi2e7DhPBU1MRPU4ZHaVqBmgM9e2HK0ae8O2AIqwqjcPo4/qR7lVGQonOQLAKOZPQCJSYfV8F5aBWzOLXElzqQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "19.0.0",
     "react-confetti": "^6.2.2",
     "react-dom": "19.0.0",
+    "react-timer-hook": "^3.0.8",
     "uuid": "^11.0.3",
     "zustand": "^5.0.1"
   },


### PR DESCRIPTION
We added more items for the "Counts" on the Dashboard page's header. Summing the tasks done today (regardless of due date), the tasks due today (and the number of them completed) along with the equivalents for the weekly tasks. 

The weekly planner page has been added - the goal of this page is to help the user plan out their week from a high level. 

Sections are broken down with prompts to help someone think about the practical things they need to get done that week. Who do they need to set up a meeting with? What hobby do they want pursue? What kind of work tasks need to be moved to the front burners? And so on. 

<img width="685" alt="image" src="https://github.com/user-attachments/assets/cdb91101-d783-40ac-9340-11209e3d655f" />

This page, and its sections, are still being hammered out. 

I want to get this UI in work before assessing what this means for the database. But right away it seems we're looking at needing a few updates:

- Add a priority column to tasks 
- Somehow track the tasks that are falling into each category here? Or maybe base the categories on tags instead. 
- Track when a user has already planned the current week. Then we can display a filled out planner sheet when they visit the plan/week page - with a button to allow them to edit the week, of course. 