### PR TITLE
a11y update: dashboard stats and task items

### DIFF
--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -76,6 +76,9 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   return (
     <div
       className={`relative flex items-center justify-between p-4 mb-2 ${bgColor} ${borderColor} rounded-md shadow-sm hover:shadow-md transition-shadow`}
+      role="group"
+      aria-labelledby={`task-label-${task.id}`}
+      aria-describedby={task.dueDate ? `task-due-${task.id}` : undefined}
     >
       <div>
         <div className="flex items-center space-x-4">
@@ -83,12 +86,13 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
             type="checkbox"
             id={`task-${task.id}`}
             name={`task-${task.id}`}
-            aria-label="Mark task as complete"
+            aria-label={`${checked ? 'Unselect' : 'Select'} task ${task.text}`}
             checked={checked}
             className="form-checkbox h-5 w-5 rounded focus:outline focus:outline-highlight"
             onChange={handleCheckboxChange}
           />
           <span
+            id={`task-label-${task.id}`}
             className={`text-gray-800 ${
               task.completed ? 'line-through italic' : ''
             }`}
@@ -97,7 +101,10 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
           </span>
         </div>
         {task.dueDate && (
-          <span className="text-gray-500 text-xs ml-2">
+          <span
+            id={`task-due-${task.id}`}
+            className="text-gray-500 text-xs ml-2"
+          >
             Due: {new Date(task.dueDate).toDateString()}
           </span>
         )}
@@ -106,6 +113,9 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
         <ToggleCompletionButton
           isCompleted={task.completed}
           onToggle={() => toggleCompleteTask(task.id)}
+          ariaLabel={`Mark task ${task.text} as ${
+            task.completed ? 'incomplete' : 'complete'
+          }`}
         />
         <MeatballMenu
           menuOpen={menuOpen}

--- a/app/components/ClientTaskList/TaskItem/ToggleCompletionButton.tsx
+++ b/app/components/ClientTaskList/TaskItem/ToggleCompletionButton.tsx
@@ -5,11 +5,13 @@ import Confetti from 'react-confetti';
 type ToggleCompletionButtonProps = {
   isCompleted: boolean;
   onToggle: () => void;
+  ariaLabel: string;
 };
 
 const ToggleCompletionButton = ({
   isCompleted,
   onToggle,
+  ariaLabel,
 }: ToggleCompletionButtonProps) => {
   const [showConfetti, setShowConfetti] = useState(false);
 
@@ -36,7 +38,7 @@ const ToggleCompletionButton = ({
             ? 'bg-highlight border-highlight text-white'
             : 'bg-gray-200 border-gray-400 text-gray-600'
         )}
-        aria-label={isCompleted ? 'Mark as incomplete' : 'Mark as complete'}
+        aria-label={ariaLabel}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/app/components/DashboardStats.tsx
+++ b/app/components/DashboardStats.tsx
@@ -3,9 +3,6 @@
 import React from 'react';
 import { useStatStore } from '@/lib/store/stat';
 
-const statContainerStyles =
-  'bg-utility rounded p-2 text-xs font-semibold text-text shadow-sm';
-
 const DashboardStats = () => {
   const {
     completedThisWeek,
@@ -17,37 +14,57 @@ const DashboardStats = () => {
   } = useStatStore();
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-2">
-      <div className={statContainerStyles}>
-        <p>Today</p>
-        <div className="flex justify-center p-1">
-          <p className="text-lg">{completedToday}</p>
-        </div>
-      </div>
-      <div className={statContainerStyles}>
-        <p>This Week</p>
-        <div className="flex justify-center p-1">
-          <p className="text-lg">{completedThisWeek}</p>
-        </div>
-      </div>
-      <div className={statContainerStyles}>
-        <p>Due Today</p>
-        <div className="flex justify-center items-center p-1">
-          <p className="text-lg">{completedDueToday}</p>
-          <span className="font-light mx-1">/</span>
-          <p className="text-lg font-light">{dueToday}</p>
-        </div>
-      </div>
-      <div className={statContainerStyles}>
-        <p>Due this Week</p>
-        <div className="flex justify-center items-center p-1">
-          <p className="text-lg">{completedDueThisWeek}</p>
-          <span className="font-light mx-1">/</span>
-          <p className="text-lg font-light">{dueThisWeek}</p>
-        </div>
-      </div>
-    </div>
+    <ul className="grid grid-cols-2 md:grid-cols-4 gap-4 p-2">
+      <StatItem
+        label="Today"
+        value={completedToday}
+        ariaLabel={`${completedToday} tasks completed today`}
+      />
+      <StatItem
+        label="This Week"
+        value={completedThisWeek}
+        ariaLabel={`${completedThisWeek} tasks completed this week`}
+      />
+      <StatItem
+        label="Due Today"
+        value={completedDueToday}
+        total={dueToday}
+        ariaLabel={`${completedDueToday} tasks out of ${dueToday} tasks due today completed`}
+      />
+      <StatItem
+        label="Due this Week"
+        ariaLabel={`${completedDueThisWeek} tasks out of ${dueThisWeek} tasks due this week completed`}
+        value={completedDueThisWeek}
+        total={dueThisWeek}
+      />
+    </ul>
   );
 };
 
 export default DashboardStats;
+
+interface StatItemProps {
+  label: string;
+  ariaLabel?: string;
+  value: number;
+  total?: number;
+}
+
+const StatItem = ({ label, ariaLabel, value, total }: StatItemProps) => {
+  return (
+    <li className="bg-utility rounded p-2 text-xs font-semibold text-text shadow-sm">
+      <p>{label}</p>
+      <div className="flex justify-center items-center p-1">
+        <p className="text-lg" role="status" aria-label={ariaLabel}>
+          {value}
+        </p>
+        {total !== undefined && (
+          <>
+            <span className="font-light mx-1">/</span>
+            <p className="text-lg font-light">{total}</p>
+          </>
+        )}
+      </div>
+    </li>
+  );
+};

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -26,21 +26,23 @@ export default async function DashboardPage() {
               <DashboardGreeting username={username} />
               <Link
                 className="text-center font-bold py-2 px-4 rounded-md
-        bg-primary hover:bg-secondary text-white disabled:bg-gray-400"
+  bg-primary hover:bg-secondary text-white disabled:bg-gray-400"
                 href={'/plan/week'}
+                role="button"
+                aria-label="Go to weekly planner"
               >
-                <button>Weekly Planner</button>
+                Weekly Planner
               </Link>
             </div>
             <DashboardStats />
           </div>
         </div>
         <div className="h-screen text-black grid gap-2 grid-cols-1 md:grid-cols-2 px-4">
-          <div className="flex flex-col p-2">
+          <div role="region" aria-label="tasks" className="flex flex-col p-2">
             <ClientTaskList />
             <AddTasks />
           </div>
-          <div className="p-2">
+          <div role="region" aria-label="notes" className="p-2">
             <NoteDisplay />
             <TextEditor />
           </div>


### PR DESCRIPTION
I think I want to start trying to do an "a11y update" in this project every friday - especially since we're recording light house scores in the database, it would be cool to see where that effort lead over time. 

This time i focused on updating the dashboard stats:

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/f22b28eb-9413-4523-a684-c2ce9e6fd009" />

- Creates reusable `StatItem` component - not perfect, but it fits the use case for now, and I just kept it defined within DashboardStats for now - if it becomes larger it can receive more thought to be more extensible

The way this presented to a screen reader before was a mess, we weren't using any semantic HTML - so we fixed that by updating this UI to be a `<ul>` where each stat item is a child `<li>`. 

The items are labeled with a custom aria label, and the element containing the dynamic content is marked `role="status"`. This role means that when a user updates a task's completion status, this update is read to them in real-time by a screen reader. 

And the task items:

<img width="523" alt="image" src="https://github.com/user-attachments/assets/90202f3b-6122-439e-86e8-2c8114c20efc" />

This was presenting in an overwhelming way:

![image](https://github.com/user-attachments/assets/7f13a972-ebeb-472e-a0bd-56b6354d425a)

We updated by adding more context with `aria-labelledby` and `aria-describedby` (when a date is present). 

Now when a screen reader user moves through items they'll hear:

- "[Task Name] (draggable instructions)
- Move into the task, onto the checkbox: "checkbox Select [Task Name] unchecked/checked"
- Move to toggle completion button: "Mark [Task Name] as complete/incomplete"

These task items still need more refining for their screen reader presentation - but I need to do more research, and probably find (or build) a better drag and drop option. 