### PR TITLE
feat: Updates TaskItem checkbox appearance, adds deletion confirmations

### DIFF
--- a/app/components/ClientTaskList/TaskItem/DeleteConfirmationModal.tsx
+++ b/app/components/ClientTaskList/TaskItem/DeleteConfirmationModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Modal from '../../Modal/Modal';
+import { type TaskWithTags, useTaskStore } from '@/lib/store/task';
+import TaskItemSkeleton from '../../TaskItemSkeleton';
+type DeleteConfirmationModalProps = {
+  isDeleteModalOpen: boolean;
+  setIsDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  task: TaskWithTags;
+};
+
+const DeleteConfirmationModal = ({
+  task,
+  isDeleteModalOpen,
+  setIsDeleteModalOpen,
+}: DeleteConfirmationModalProps) => {
+  const { deleteTask } = useTaskStore();
+
+  const handleDeleteTask = () => {
+    if (!task.id) return;
+    deleteTask(task.id);
+    setIsDeleteModalOpen(false);
+  };
+  return (
+    <Modal
+      isOpen={isDeleteModalOpen}
+      onClose={() => setIsDeleteModalOpen(false)}
+    >
+      <div className="flex flex-col gap-4">
+        <h1 className="text-lg font-semibold">Delete Task</h1>
+        <p>Are you sure you want to delete this task?</p>
+        <TaskItemSkeleton task={task} />
+        <div className="flex gap-2">
+          <button
+            className="w-full text-center font-bold py-2 px-4 rounded-md
+        bg-highlight hover:bg-secondary text-white"
+            onClick={() => setIsDeleteModalOpen(false)}
+          >
+            Cancel
+          </button>
+          <button
+            className="w-full text-center font-bold py-2 px-4 rounded-md
+        bg-primary hover:bg-secondary text-white"
+            onClick={handleDeleteTask}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -7,6 +7,7 @@ import { useNoteStore } from '@/lib/store/note';
 import { useStatStore } from '@/lib/store/stat';
 import { useStore } from '@/lib/store/app';
 import { useSelectedTaskStore } from '@/lib/store/selected.task';
+import DeleteConfirmationModal from './DeleteConfirmationModal';
 import DueDateModal from './DueDateModal';
 import MeatballMenu from '../../MeatballMenu';
 import ToggleCompletionButton from './ToggleCompletionButton';
@@ -21,8 +22,9 @@ import type { TaskWithTags } from '@/lib/store/task';
  */
 const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDueDateModalOpen, setIsDueDateModalOpen] = useState(false);
-  const { deleteTask, toggleComplete } = useTaskStore();
+  const { toggleComplete } = useTaskStore();
   const { updateStats } = useStatStore();
   const { selectedTaskIds, setSelectedTaskIds } = useSelectedTaskStore();
   const { isLinking } = useNoteStore();
@@ -60,7 +62,7 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
     {
       label: 'Delete',
       onClick: () => {
-        deleteTask(task.id);
+        setIsDeleteModalOpen(!isDeleteModalOpen);
         setMenuOpen(false);
       },
     },
@@ -122,7 +124,13 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
               checked:bg-highlight checked:border-highlight 
             "
           />
-          <span className="text-gray-900">{task.text}</span>
+          <span
+            className={`text-gray-900 ${
+              task.completed && 'line-through italic'
+            }`}
+          >
+            {task.text}
+          </span>
 
           {/* Checkmark inside the checkbox */}
           {checked && (
@@ -171,6 +179,11 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
         task={task}
         isDueDateModalOpen={isDueDateModalOpen}
         setIsDueDateModalOpen={setIsDueDateModalOpen}
+      />
+      <DeleteConfirmationModal
+        task={task}
+        isDeleteModalOpen={isDeleteModalOpen}
+        setIsDeleteModalOpen={setIsDeleteModalOpen}
       />
     </div>
   );

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -38,7 +38,7 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   // TODO - better classes - clsx?
   const borderColor = selectedTaskIds.includes(task.id)
     ? 'border-2 border-highlight'
-    : '';
+    : 'border-2 border-transparent';
 
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
@@ -75,20 +75,27 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
 
   return (
     <div
-      className={`relative flex items-center justify-between p-4 mb-2 ${bgColor} ${borderColor} rounded-md shadow-sm hover:shadow-md transition-shadow`}
+      className={`relative flex items-center justify-between p-4 mb-2 ${bgColor} ${borderColor} rounded-md shadow-sm hover:shadow-md transition-shadow gap-2`}
       role="group"
       aria-labelledby={`task-label-${task.id}`}
       aria-describedby={task.dueDate ? `task-due-${task.id}` : undefined}
     >
       <div>
-        <div className="flex items-center space-x-4">
+        {/* <div className="flex items-center space-x-4">
           <input
             type="checkbox"
             id={`task-${task.id}`}
             name={`task-${task.id}`}
             aria-label={`${checked ? 'Unselect' : 'Select'} task ${task.text}`}
             checked={checked}
-            className="form-checkbox h-5 w-5 rounded focus:outline focus:outline-highlight"
+            className="
+            appearance-none w-5 h-5 shrink-0 border-2 border-gray-400 rounded
+            flex items-center justify-center text-white
+            focus:outline focus:outline-2 focus:outline-highlight
+            checked:bg-highlight checked:border-transparent
+            relative
+            before:content-['✓'] before:absolute before:inset-0 before:flex before:items-center before:justify-center before:text-white before:font-bold before:text-lg before:opacity-0 checked:before:opacity-100
+            "
             onChange={handleCheckboxChange}
           />
           <span
@@ -99,7 +106,41 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
           >
             {task.text}
           </span>
-        </div>
+        </div> */}
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            id={`task-${task.id}`}
+            name={`task-${task.id}`}
+            aria-label={`${checked ? 'Unselect' : 'Select'} task ${task.text}`}
+            checked={checked}
+            onChange={handleCheckboxChange}
+            className="
+              relative appearance-none w-6 h-6 shrink-0 border-2 border-secondary rounded-md 
+              flex items-center justify-center 
+              focus:outline focus:outline-2 focus:outline-highlight
+              checked:bg-highlight checked:border-highlight 
+            "
+          />
+          <span className="text-gray-900">{task.text}</span>
+
+          {/* Checkmark inside the checkbox */}
+          {checked && (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="absolute w-6 h-6 text-white pointer-events-none"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          )}
+        </label>
+
         {task.dueDate && (
           <span
             id={`task-due-${task.id}`}

--- a/app/components/TaskItemSkeleton.tsx
+++ b/app/components/TaskItemSkeleton.tsx
@@ -1,0 +1,28 @@
+import { TaskWithTags } from '@/lib/store/task';
+import { COLORS } from '@/utils/constants';
+
+const TaskItemSkeleton = ({ task }: { task: TaskWithTags }) => {
+  const taskTagColor = task.taskTags.length > 0 && task.taskTags[0].tag.color;
+  const bgColor =
+    task.taskTags.length > 0
+      ? COLORS.find((color) => color.name === taskTagColor)?.background
+      : 'bg-note';
+
+  const borderColor = 'border-2 border-transparent';
+  return (
+    <div
+      className={`relative flex items-center justify-between p-4 mb-2 ${bgColor} ${borderColor} rounded-md shadow-sm hover:shadow-md transition-shadow gap-2`}
+    >
+      <div>
+        <p>{task.text}</p>
+        {task.dueDate && (
+          <span id={`task-due-${task.id}`} className="text-gray-500 text-xs">
+            Due: {new Date(task.dueDate).toDateString()}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskItemSkeleton;

--- a/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
+++ b/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Modal from '../Modal/Modal';
+import { useTaskStore } from '@/lib/store/task';
+import { useSelectedTaskStore } from '@/lib/store/selected.task';
+import TaskItemSkeleton from '../TaskItemSkeleton';
+type DeleteConfirmationModalProps = {
+  isMassDeleteModalOpen: boolean;
+  setIsMassDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const MassDeleteConfirmationModal = ({
+  isMassDeleteModalOpen,
+  setIsMassDeleteModalOpen,
+}: DeleteConfirmationModalProps) => {
+  const { tasks, deleteSelectedTasks } = useTaskStore();
+  const { selectedTaskIds } = useSelectedTaskStore();
+
+  const selectedTasks = tasks.filter((task) =>
+    selectedTaskIds.includes(task.id)
+  );
+
+  const handleDeleteTasks = () => {
+    if (selectedTasks) return;
+    deleteSelectedTasks();
+    setIsMassDeleteModalOpen(false);
+  };
+  return (
+    <Modal
+      isOpen={isMassDeleteModalOpen}
+      onClose={() => setIsMassDeleteModalOpen(false)}
+    >
+      <div className="flex flex-col gap-4">
+        <h1 className="text-lg font-semibold">Delete Task</h1>
+        <p>Are you sure you want to delete these tasks?</p>
+        {selectedTasks &&
+          selectedTasks.map((task) => (
+            <TaskItemSkeleton key={task.id} task={task} />
+          ))}
+        <div className="flex gap-2">
+          <button
+            className="w-full text-center font-bold py-2 px-4 rounded-md
+        bg-highlight hover:bg-secondary text-white"
+            onClick={() => setIsMassDeleteModalOpen(false)}
+          >
+            Cancel
+          </button>
+          <button
+            className="w-full text-center font-bold py-2 px-4 rounded-md
+        bg-primary hover:bg-secondary text-white"
+            onClick={handleDeleteTasks}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default MassDeleteConfirmationModal;

--- a/app/components/TasksToolbar.tsx/TasksToolbar.tsx
+++ b/app/components/TasksToolbar.tsx/TasksToolbar.tsx
@@ -6,6 +6,7 @@ import { useTagStore } from '@/lib/store/tag';
 import { useStore } from '@/lib/store/app';
 import TagItem from './TagItem';
 import AddTagModal from './AddTagModal';
+import MassDeleteConfirmationModal from './MassDeleteConfirmationModal';
 
 //TODO: break this component up
 
@@ -14,9 +15,10 @@ const buttonClass =
 const checkboxLabelClass = 'flex items-center text-sm font-semibold text-text';
 const TasksToolbar = () => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [isMassDeleteModalOpen, setIsMassDeleteModalOpen] =
+    React.useState(false);
   const {
     selectAllTasks,
-    deleteSelectedTasks,
     setSelectedTagId,
     selectedTagIds,
     clearSelectedTags,
@@ -96,7 +98,7 @@ const TasksToolbar = () => {
               </button>
               <button
                 className={buttonClass}
-                onClick={deleteSelectedTasks}
+                onClick={() => setIsMassDeleteModalOpen(true)}
                 disabled={isLinking || !selectedTaskIds.length}
               >
                 Delete Selected
@@ -114,6 +116,12 @@ const TasksToolbar = () => {
               <AddTagModal
                 isModalOpen={isModalOpen}
                 setIsModalOpen={setIsModalOpen}
+              />
+            )}
+            {isMassDeleteModalOpen && (
+              <MassDeleteConfirmationModal
+                isMassDeleteModalOpen={isMassDeleteModalOpen}
+                setIsMassDeleteModalOpen={setIsMassDeleteModalOpen}
               />
             )}
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
   --background: #f4f7f5;
   --foreground: #f4f7f5;
   --color-primary: #21a0a0;
-  --color-secondary: #046865;
+  --color-secondary: #869f9f;
   --color-text: #074846;
   --color-note: #e9f7ee;
   --color-highlight: #41d070;
@@ -34,7 +34,7 @@
   --background: #1a171b;
   --foreground: #f4f7f5;
   --color-primary: #61195c;
-  --color-secondary: #42113e;
+  --color-secondary: #90798e;
   --color-text: #efe9e7;
   --color-note: #ecd5ec;
   --color-highlight: #e766cd;
@@ -60,7 +60,7 @@
   --background: #0d1b2a;
   --foreground: #1b263b;
   --color-primary: #3c51cb;
-  --color-secondary: #7b42dd;
+  --color-secondary: #8c7ea6;
   --color-text: #c5cbe3;
   --color-note: #ccb6f1;
   --color-highlight: #9c27b0;


### PR DESCRIPTION
## Changes 

- Fixes the previously inconsistent appearance of checkbox inputs - if content was long the checkbox would be squished down into a smaller box. We now take full control of checkbox appearance

<img width="497" alt="image" src="https://github.com/user-attachments/assets/706e8104-21c9-4e1d-90f3-e1222bf92dbd" />

- Deletion confirmation - 2 modals have been added to confirm deletions:

<img width="462" alt="image" src="https://github.com/user-attachments/assets/7779a27a-2105-4d7c-ba03-95b3b4971027" />
<img width="547" alt="image" src="https://github.com/user-attachments/assets/b9fcd752-23fd-4ea0-a692-c567725b2a37" />

This feels like a step in the right direction to making this feel a little more polished - and give the user a better understanding of what they are deleting. 