### PR TITLE
feat: Migrate Tasks and Tags to indexDB 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "workbench.colorCustomizations": {}
+  "workbench.colorCustomizations": {},
+  "cSpell.words": ["Dexie"]
 }

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,6 +1,14 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
-import type { TaskWithTags } from '@/lib/store/task';
+import { Task, Tag } from '@prisma/client';
+
+export interface PrismaTaskWithTags extends Task {
+  taskTags: Array<{
+    taskId: string;
+    tagId: string;
+    tag: Tag | null;
+  }>;
+}
 
 /**
  * Handles a GET request to fetch tasks for a given user.
@@ -21,11 +29,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(req.url);
   const userId = searchParams.get('userId');
 
-  // TODO: Since we're deploying in Amplify, build a small logger for nicely formatted logs
-  // And set up a custom error handler and configure Amplify to use it
-  // console.log('🚀 Incoming request to fetch tasks!');
-  // console.log('🔍 Received userId:', userId);
-  // console.log('🔍 Received tagId:', tagId);
+  // TODO: make sure the types match up with Dexie
 
   if (!userId) {
     console.error('❌ ERROR: Missing userId in request');
@@ -39,7 +43,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   try {
     console.log('🔍 Fetching all tasks for userId:', userId);
-    const tasks: TaskWithTags[] = await prisma.task.findMany({
+    const tasks: PrismaTaskWithTags[] = await prisma.task.findMany({
       where: { userId },
       include: {
         taskTags: {

--- a/app/components/ClientTaskList/SortableTaskItem.tsx
+++ b/app/components/ClientTaskList/SortableTaskItem.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import TaskItem from './TaskItem/TaskItem';
-import type { TaskWithTags } from '@/lib/store/task';
+import { TaskWithTags } from '@/lib/services/task';
 // SEE DOCS: https://docs.dndkit.com/presets/sortable
 
 /**

--- a/app/components/ClientTaskList/TaskItem/DeleteConfirmationModal.tsx
+++ b/app/components/ClientTaskList/TaskItem/DeleteConfirmationModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Modal from '../../Modal/Modal';
-import { type TaskWithTags, useTaskStore } from '@/lib/store/task';
+import { useTaskStore } from '@/lib/store/task';
+import type { TaskWithTags } from '@/lib/services/task';
 import TaskItemSkeleton from '../../TaskItemSkeleton';
 import { primaryButtonStyles, secondaryButtonStyles } from '@/lib/style';
 type DeleteConfirmationModalProps = {

--- a/app/components/ClientTaskList/TaskItem/DueDateModal.tsx
+++ b/app/components/ClientTaskList/TaskItem/DueDateModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Modal from '../../Modal/Modal';
 import { useTaskStore } from '@/lib/store/task';
-import type { TaskWithTags } from '@/lib/store/task';
+import type { TaskWithTags } from '@/lib/services/task';
 import { primaryButtonStyles, secondaryButtonStyles } from '@/lib/style';
 
 type DueDateModalProps = {

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -11,7 +11,7 @@ import DeleteConfirmationModal from './DeleteConfirmationModal';
 import DueDateModal from './DueDateModal';
 import MeatballMenu from '../../MeatballMenu';
 import ToggleCompletionButton from './ToggleCompletionButton';
-import type { TaskWithTags } from '@/lib/store/task';
+import type { TaskWithTags } from '@/lib/services/task';
 
 /**
  * A component to render a single task.
@@ -30,7 +30,11 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
   const { isLinking } = useNoteStore();
   const { disableColorCodeTasks } = useStore();
 
-  const taskTagColor = task.taskTags.length > 0 && task.taskTags[0].tag.color;
+  const taskTagColor =
+    task.taskTags.length > 0 && task?.taskTags[0]?.tag?.color;
+  // log with formatting
+  console.log(`TaskItem: taskTagColor: ${taskTagColor}`);
+  console.log(`Task Tags: ${JSON.stringify(task.taskTags)}`);
 
   const bgColor =
     task.taskTags.length > 0 && !disableColorCodeTasks
@@ -120,7 +124,7 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
             className="
               relative appearance-none w-6 h-6 shrink-0 border-2 border-secondary rounded-md 
               flex items-center justify-center 
-              focus:outline focus:outline-2 focus:outline-highlight
+              focus:outline-2 focus:outline-highlight
               checked:bg-highlight checked:border-highlight 
             "
           />

--- a/app/components/ClientTaskList/TaskItem/TaskItem.tsx
+++ b/app/components/ClientTaskList/TaskItem/TaskItem.tsx
@@ -32,9 +32,6 @@ const TaskItem = ({ task }: { task: TaskWithTags }): React.ReactElement => {
 
   const taskTagColor =
     task.taskTags.length > 0 && task?.taskTags[0]?.tag?.color;
-  // log with formatting
-  console.log(`TaskItem: taskTagColor: ${taskTagColor}`);
-  console.log(`Task Tags: ${JSON.stringify(task.taskTags)}`);
 
   const bgColor =
     task.taskTags.length > 0 && !disableColorCodeTasks

--- a/app/components/TaskItemSkeleton.tsx
+++ b/app/components/TaskItemSkeleton.tsx
@@ -1,8 +1,8 @@
-import { TaskWithTags } from '@/lib/store/task';
+import type { TaskWithTags } from '@/lib/services/task';
 import { COLORS } from '@/utils/constants';
 
 const TaskItemSkeleton = ({ task }: { task: TaskWithTags }) => {
-  const taskTagColor = task.taskTags.length > 0 && task.taskTags[0].tag.color;
+  const taskTagColor = task.taskTags.length > 0 && task.taskTags[0]?.tag?.color;
   const bgColor =
     task.taskTags.length > 0
       ? COLORS.find((color) => color.name === taskTagColor)?.background

--- a/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
+++ b/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
@@ -21,7 +21,8 @@ const MassDeleteConfirmationModal = ({
   );
 
   const handleDeleteTasks = () => {
-    if (selectedTasks) return;
+    console.log("Clicked 'Confirm'", selectedTasks);
+    if (!selectedTasks) return;
     deleteSelectedTasks();
     setIsMassDeleteModalOpen(false);
   };

--- a/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
+++ b/app/components/TasksToolbar.tsx/MassDeleteConfirmationModal.tsx
@@ -21,7 +21,6 @@ const MassDeleteConfirmationModal = ({
   );
 
   const handleDeleteTasks = () => {
-    console.log("Clicked 'Confirm'", selectedTasks);
     if (!selectedTasks) return;
     deleteSelectedTasks();
     setIsMassDeleteModalOpen(false);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -14,6 +14,7 @@ export interface Task {
   position: number;
   userId?: string; // the id of the user that created the task
   dueDate?: Date;
+  priority?: number;
 }
 
 export interface Tag {

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -5,3 +5,10 @@ import { TagsService } from './tags';
 export const taskService = new TaskService();
 export const noteService = new NoteService();
 export const tagsService = new TagsService();
+
+/**
+ * Standardized response type for service methods
+ */
+export type ServiceResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };

--- a/lib/services/tags.ts
+++ b/lib/services/tags.ts
@@ -1,5 +1,6 @@
 import { db, Tag } from '../db';
-
+import { v4 as uuidv4 } from 'uuid';
+import type { ServiceResponse } from '@/lib/services';
 /**
  * The TagsService is responsible for all CRUD operations on the tags table in the database
  *
@@ -8,39 +9,72 @@ import { db, Tag } from '../db';
  * tasks to tags
  */
 export class TagsService {
-  async createTag(userId: string, name: string, color?: string): Promise<Tag> {
-    const response = await fetch('/api/tags', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, name, color }),
-    });
-    if (!response.ok) throw new Error('Failed to create tag');
-    return response.json();
+  async createTag(
+    userId: string,
+    name: string,
+    color?: string
+  ): Promise<ServiceResponse<Tag>> {
+    try {
+      const newTagId = uuidv4();
+      const newTag: Tag = {
+        id: newTagId,
+        name,
+        color,
+        userId,
+      };
+      await db.tags.add(newTag);
+      return { success: true, data: newTag };
+    } catch (error) {
+      console.error('Failed to create tag:', error);
+      return { success: false, error: 'Failed to create tag' };
+    }
   }
-  async getTagsByUser(userId: string) {
-    const tags = await fetch(`/api/tags?userId=${userId}`);
-    if (!tags.ok) throw new Error('Failed to fetch tags');
-    return tags;
+  async getTagsByUser(userId: string): Promise<ServiceResponse<Tag[]>> {
+    try {
+      const tags = await db.tags.where('userId').equals(userId).toArray();
+      return { success: true, data: tags };
+    } catch (error) {
+      console.error('Failed to fetch tags:', error);
+      return { success: false, error: 'Failed to fetch tags' };
+    }
   }
 
-  // NEEDS UPDATING
-  async deleteTag(tagId: string) {
-    await db.tags.delete(tagId);
-    await db.taskTags.where('tagId').equals(tagId).delete();
+  // All of these are unused, but need to be implemented
+  async deleteTag(tagId: string): Promise<ServiceResponse<boolean>> {
+    try {
+      await db.tags.delete(tagId);
+      await db.taskTags.where('tagId').equals(tagId).delete();
+      return { success: true, data: true };
+    } catch (error) {
+      console.error('Failed to delete tag:', error);
+      return { success: false, error: 'Failed to delete tag' };
+    }
   }
-  async linkTagToTask(tagId: string, taskId: string) {
-    await db.taskTags.add({ tagId, taskId });
+  async linkTagToTask(
+    tagId: string,
+    taskId: string
+  ): Promise<ServiceResponse<boolean>> {
+    try {
+      await db.taskTags.add({ tagId, taskId });
+      return { success: true, data: true };
+    } catch (error) {
+      console.error('Failed to link tag to task:', error);
+      return { success: false, error: 'Failed to link tag to task' };
+    }
   }
-  async unlinkTagFromTask(tagId: string, taskId: string) {
-    await db.taskTags.where('[taskId+tagId]').equals([taskId, tagId]).delete();
-  }
-  async getTasksByTag(tagId: string) {
-    const taskIds = await db.taskTags
-      .where('tagId')
-      .equals(tagId)
-      .toArray()
-      .then((taskIds) => taskIds.map((task) => task.taskId));
-
-    return db.tasks.bulkGet(taskIds);
+  async unlinkTagFromTask(
+    tagId: string,
+    taskId: string
+  ): Promise<ServiceResponse<boolean>> {
+    try {
+      await db.taskTags
+        .where('[taskId+tagId]')
+        .equals([taskId, tagId])
+        .delete();
+      return { success: true, data: true };
+    } catch (error) {
+      console.error('Failed to unlink tag from task:', error);
+      return { success: false, error: 'Failed to unlink tag from task' };
+    }
   }
 }

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -63,7 +63,6 @@ export class TaskService {
       return [];
     }
   }
-
   /**
    * Adds a new task for a given user with the given properties.
    *

--- a/lib/services/task.ts
+++ b/lib/services/task.ts
@@ -1,4 +1,6 @@
 import { type ServiceAddTaskInput } from '@/types/service';
+import { db, Task, Tag } from '../db';
+import { v4 as uuidv4 } from 'uuid';
 
 /** This file holds the Task service
  * The Task service is responsible for CRUD operations on the tasks table in the database
@@ -7,106 +9,182 @@ import { type ServiceAddTaskInput } from '@/types/service';
 // TODO:
 // Update the types with Prisma types - add Promise<type> returns
 
+export interface TaskWithTags extends Task {
+  taskTags: Array<{
+    taskId: string;
+    tagId: string;
+    tag: Tag | null;
+  }>;
+}
 export class TaskService {
-  async getAllTasks(userId: string) {
+  /**
+   * Fetches all tasks for a given user, along with their tags
+   *
+   * The function first fetches the tasks for the user, then fetches the
+   * associated tags, and finally enriches the tasks with the tags.
+   *
+   * @param {string} userId The id of the user for which to fetch tasks
+   * @returns {Promise<TaskWithTags[]>} A promise resolving to an array of tasks
+   * with their associated tags
+   */
+  async getAllTasks(userId: string): Promise<TaskWithTags[]> {
     try {
-      const response = await fetch(`/api/tasks?userId=${userId}`);
-      if (!response.ok) throw new Error('Failed to fetch tasks');
-      return await response.json();
-    } catch (error) {
-      console.error('Failed to fetch tasks:', error);
-      return [];
-    }
-  }
-  async getAllTasksById(userId: string, tagId: string) {
-    try {
-      const response = await fetch(
-        `/api/tasks?userId=${userId}&tagId=${tagId}`
+      // Fetch tasks by user id
+      const tasks = await db.tasks.where('userId').equals(userId).toArray();
+
+      // If we have no tasks we can return now
+      if (tasks.length === 0) return [];
+
+      // We have tasks - do they have tags?
+      const taskTags = await db.taskTags
+        .where('taskId')
+        .anyOf(tasks.map((task) => task.id))
+        .toArray();
+
+      // If we have no tags we can return now with the tasks
+      if (taskTags.length === 0) {
+        return tasks.map((task) => ({ ...task, taskTags: [] }));
+      }
+
+      // We've found tasks, and they have tags
+      const tags = await db.tags.bulkGet(
+        taskTags.map((taskTag) => taskTag.tagId)
       );
-      if (!response.ok) throw new Error('Failed to fetch tasks');
-      return await response.json();
+
+      // Enrich the tasks with their tags
+      return tasks.map((task) => ({
+        ...task,
+        taskTags: taskTags
+          .filter((tt) => tt.taskId === task.id)
+          .map((tt) => ({
+            taskId: tt.taskId,
+            tagId: tt.tagId,
+            tag: tags.find((tag) => tag?.id === tt.tagId) || null,
+          })),
+      }));
     } catch (error) {
       console.error('Failed to fetch tasks:', error);
       return [];
     }
   }
+
   async addTask({
     userId,
     text,
     tagIds,
     dueDate,
     priority,
-  }: ServiceAddTaskInput) {
-    const taskDueDate = dueDate ? new Date(dueDate) : null;
+  }: ServiceAddTaskInput): Promise<TaskWithTags | null> {
     try {
-      const response = await fetch('/api/tasks', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ userId, text, tagIds, taskDueDate, priority }),
-      });
+      // Gen. id for task
+      const newTaskId = uuidv4();
+      const taskDueDate = dueDate ? new Date(dueDate) : undefined;
 
-      if (!response.ok) throw new Error('Failed to add task');
-      const newTask = await response.json();
-      return newTask;
+      // Find the highest position value among the user's tasks
+      const highestPositionTask = await db.tasks
+        .where('userId')
+        .equals(userId)
+        .sortBy('position'); // Sorts in ascending order
+
+      const highestPosition = highestPositionTask.length
+        ? highestPositionTask[highestPositionTask.length - 1].position
+        : 0;
+
+      // Assign a new float position (e.g., next step could be highest + 1.0)
+      const newTaskPosition = highestPosition + 1.0;
+
+      // Create the new task
+      const newTask: Task = {
+        id: newTaskId,
+        userId,
+        text,
+        completed: false,
+        completedBy: undefined,
+        color: undefined,
+        dateAdded: new Date(),
+        dateUpdated: new Date(),
+        position: newTaskPosition,
+        dueDate: taskDueDate,
+        priority,
+      };
+
+      await db.tasks.add(newTask);
+
+      // If there are tags, create task-tag relationships
+      const taskTags = tagIds?.map((tagId) => ({
+        taskId: newTaskId,
+        tagId,
+      }));
+      if (taskTags && taskTags.length > 0) {
+        await db.taskTags.bulkAdd(taskTags);
+      }
+
+      // Fetch the tags to return in the correct TaskWithTags shape
+      const tags = tagIds ? await db.tags.bulkGet(tagIds) : [];
+      const taskWithTags: TaskWithTags = {
+        ...newTask,
+        taskTags: (taskTags ?? []).map((tt) => ({
+          taskId: tt.taskId,
+          tagId: tt.tagId,
+          tag: tags.find((tag) => tag?.id === tt.tagId) || null,
+        })),
+      };
+
+      return taskWithTags;
     } catch (error) {
       console.error('Failed to add task:', error);
-      return null; // return false? Is that a better practice?
-    }
-  }
-  async deleteTask(id: string) {
-    try {
-      const response = await fetch('/api/tasks', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ id: id }),
-      });
-      if (!response.ok) throw new Error('Failed to delete tasks');
-      const deletedTasks = await response.json();
-      return deletedTasks;
-    } catch (error) {
-      console.error('Failed to delete tasks:', error);
       return null;
     }
   }
-  async deleteTasksByIds(taskIds: string[]) {
+  async deleteTask(id: string): Promise<boolean> {
     try {
-      const response = await fetch('/api/tasks', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ id: taskIds }),
-      });
-      if (!response.ok) throw new Error('Failed to delete tasks');
-      const deletedTasks = await response.json();
-      return deletedTasks;
+      // Delete related taskTags first to maintain data integrity
+      await db.taskTags.where('taskId').equals(id).delete();
+
+      // Delete the task
+      await db.tasks.where('id').equals(id).delete();
+
+      return true;
+    } catch (error) {
+      console.error('Failed to delete task:', error);
+      return false;
+    }
+  }
+
+  async deleteTasksByIds(taskIds: string[]): Promise<boolean> {
+    try {
+      if (taskIds.length === 0) return false;
+
+      // Delete related taskTags in bulk
+      await db.taskTags.where('taskId').anyOf(taskIds).delete();
+
+      // Delete the tasks in bulk
+      await db.tasks.where('id').anyOf(taskIds).delete();
+
+      return true;
     } catch (error) {
       console.error('Failed to delete tasks:', error);
-      return null;
+      return false;
     }
   }
   async toggleComplete(id: string, userId: string, completed: boolean) {
-    const dateUpdated = new Date();
     try {
-      const response = await fetch('/api/tasks', {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          id: id,
-          completed,
-          dateUpdated,
-          completedBy: completed ? userId : null, // if removing completion, set completedBy to null
-        }),
-      });
+      const dateUpdated = new Date();
+      const task = await db.tasks.get(id);
+      if (!task) {
+        console.log(`❌ Task not found: ${id}`);
+        return null;
+      }
 
-      if (!response.ok) throw new Error('Failed to toggle task completion');
-      const updatedTask = await response.json();
+      // Update the task in Dexie
+      const updatedTask: Task = {
+        ...task,
+        completed,
+        completedBy: completed ? userId : undefined, // if removing completion, set completedBy to null
+        dateUpdated,
+      };
+      await db.tasks.update(id, updatedTask);
+
       return updatedTask;
     } catch (error) {
       console.error('Failed to toggle task completion:', error);

--- a/lib/store/tag.ts
+++ b/lib/store/tag.ts
@@ -19,12 +19,12 @@ export const useTagStore = create<TagStore>()(
       currentTag: null,
       fetchTags: async () => {
         const userId = useStore.getState().userId;
-        if (!userId) return;
+        if (!userId) return console.warn('User ID is required');
         try {
-          const userTags = await tagsService.getTagsByUser(userId);
-          if (!userTags.ok) throw new Error('Failed to fetch tags');
-          const allTags = await userTags.json();
-          set({ tags: allTags });
+          const response = await tagsService.getTagsByUser(userId);
+          if (!response.success) throw new Error(response.error);
+          const userTags = response.data;
+          set({ tags: userTags });
         } catch (error) {
           console.error('Failed to fetch tags:', error);
         }
@@ -32,8 +32,9 @@ export const useTagStore = create<TagStore>()(
       addTag: async (name: string, color?: string) => {
         const userId = useStore.getState().userId;
         if (!userId) return console.warn('User ID is required');
-        const newTag = await tagsService.createTag(userId, name, color);
-        if (!newTag) throw new Error('Failed to create tag');
+        const response = await tagsService.createTag(userId, name, color);
+        if (!response.success) throw new Error(response.error);
+        const newTag = response.data;
         set((state) => ({ tags: [...state.tags, newTag] }));
       },
       setCurrentTag: (tag) => {

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -1,18 +1,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { taskService } from '@/lib/services';
+import { type TaskWithTags } from '../services/task';
 import { useSelectedTaskStore } from './selected.task';
 import { useStore } from './app';
-import { Task, Tag } from '@prisma/client';
 import { type AddTaskInput } from '@/types/service';
-// Define TaskWithTags to include the `taskTags` relation
-export interface TaskWithTags extends Task {
-  taskTags: Array<{
-    taskId: string;
-    tagId: string;
-    tag: Tag;
-  }>;
-}
+//import { Task, Tag } from '@prisma/client'; // we don't want to use Prisma types here?
+
 interface TaskStore {
   tasks: TaskWithTags[];
   fetchTasks: () => Promise<void>;
@@ -56,7 +50,6 @@ export const useTaskStore = create<TaskStore>()(
         if (!userId) return;
 
         try {
-          // fetch all user's tasks
           const fetchedTasks = await taskService.getAllTasks(userId);
           // Set the tasks in the store
           set({ tasks: fetchedTasks });

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -167,11 +167,10 @@ export const useTaskStore = create<TaskStore>()(
 
         // Find index of task being dragged
         const activeIndex = tasks.findIndex((task) => task.id === activeId);
-        // And task being hovered over
+        // Find index of task being hovered over
         const overIndex = tasks.findIndex((task) => task.id === overId);
 
         if (
-          // If either task is not found, do nothing
           activeIndex === -1 ||
           overIndex === -1 ||
           activeIndex === overIndex
@@ -183,21 +182,21 @@ export const useTaskStore = create<TaskStore>()(
         const [movedTask] = tasks.splice(activeIndex, 1);
         tasks.splice(overIndex, 0, movedTask);
 
-        // Calculate the new position for moved task
-        const prevTask = tasks[overIndex - 1];
-        const nextTask = tasks[overIndex + 1];
+        // Get surrounding tasks
+        const prevTask = tasks[overIndex - 1] || null; // Ensure it's either a task or null
+        const nextTask = tasks[overIndex + 1] || null;
 
-        let newPosition;
+        let newPosition: number;
 
-        if (prevTask.position && nextTask.position) {
+        if (prevTask && nextTask) {
           // Average of adjacent task positions
           newPosition = (prevTask.position + nextTask.position) / 2;
-        } else if (prevTask.position) {
+        } else if (prevTask) {
           newPosition = prevTask.position + 1; // Place at the end
-        } else if (nextTask.position) {
+        } else if (nextTask) {
           newPosition = nextTask.position / 2; // Place at the start
         } else {
-          newPosition = 1; // Fallback - place at start
+          newPosition = 1; // Fallback if no neighbors exist
         }
 
         await taskService.updateTaskPosition(activeId, newPosition);

--- a/lib/store/task.ts
+++ b/lib/store/task.ts
@@ -50,8 +50,10 @@ export const useTaskStore = create<TaskStore>()(
         if (!userId) return;
 
         try {
-          const fetchedTasks = await taskService.getAllTasks(userId);
-          // Set the tasks in the store
+          const response = await taskService.getAllTasks(userId);
+          if (!response.success) throw new Error(response.error);
+
+          const fetchedTasks = response.data;
           set({ tasks: fetchedTasks });
           set({ loadingTasks: false });
         } catch (error) {
@@ -59,19 +61,24 @@ export const useTaskStore = create<TaskStore>()(
         }
       },
       addTask: async ({ text, tagIds, dueDate, priority }) => {
-        const userId = useStore.getState().userId;
-        if (!userId) return;
+        try {
+          const userId = useStore.getState().userId;
+          if (!userId) return;
 
-        const newTask = await taskService.addTask({
-          userId,
-          text,
-          tagIds,
-          dueDate,
-          priority,
-        });
-        if (!newTask) throw new Error('There was a problem adding the task');
+          const response = await taskService.addTask({
+            userId,
+            text,
+            tagIds,
+            dueDate,
+            priority,
+          });
+          if (!response.success) throw new Error(response.error);
 
-        set((state) => ({ tasks: [...state.tasks, newTask] }));
+          const newTask = response.data;
+          set((state) => ({ tasks: [...state.tasks, newTask] }));
+        } catch (error) {
+          console.error('Failed to add task:', error);
+        }
       },
       /**
        * Selects all tasks based on current filters and updates the selectedTaskIds.

--- a/lib/style/index.ts
+++ b/lib/style/index.ts
@@ -2,7 +2,7 @@ export const navigationButtonStyles =
   'font-bold py-2 px-4 rounded-md bg-primary hover:bg-tertiary text-white';
 
 export const primaryButtonStyles =
-  'font-bold py-2 px-4 rounded-md bg-primary hover:bg-secondary text-white disabled:bg-gray-400';
+  'font-bold py-2 px-4 rounded-md bg-primary hover:bg-secondary text-white disabled:bg-gray-400 disabled:cursor-not-allowed cursor-pointer';
 
 export const secondaryButtonStyles =
-  'font-bold py-2 px-4 rounded-md bg-utility hover:bg-secondary text-white';
+  'font-bold py-2 px-4 rounded-md bg-utility hover:bg-secondary text-white cursor-pointer disabled:bg-gray-400 disabled:cursor-not-allowed';


### PR DESCRIPTION
## Introduction 

In our last PR we updated the Dexie db to match what has been built in Prisma and RDS. However, this app was built with the intent to be offline-first, and to allow the user to share as little or as much of their data as they want. 

Original tables and functionality was completely built with Dexie and Zustand stores. We added RDS for a more reliable persistence, and we can keep using it, but instead of relying on it in real-time we can periodically sync. 

We get several advantages here:

- Fast UI experience - Tasks, notes, etc are just *there* when the user logs in, making updates feels dang near instantaneous 
- The user can choose to completely own their data - there's no reason they need to sync their todos and habits with our DB, they can keep them on their device (but if they want to sync between devices, they'll need to enable syncing)
- Less network requests to AWS - if I'm being honest, I got a bill for $4 for this app the last month. That's not crazy - but I have a strong suspicion that relying less on our RDS instance will bring that down 

## Changes 

- Migrates Task and Tag services back to storing in Dexie 
- Adds standardized `ServiceResponse` type - guaranteeing that we always have 1 of 2 responses - either success with data, or failure and a message 
- Updates types as needed 

## Next Steps 

- Introduce an API route for syncing between Dexie and Prisma  
- Clean up API routes 
- Think about the divergent paths we are considering offering users 
- Think about how we can automate the syncing between Dexie and prisma 

These changes mean that current users will now see their tasks "reset" (or old tasks that were still in their local storage). The tasks will still be in RDS, but we'll probably end up nuking them all when setting up the syncing API route. 

But those users are me, and I'm not worried about it. 